### PR TITLE
Add stop control to restore default video loop

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,6 +1,7 @@
 const template = document.getElementById("video-card-template");
 const listEl = document.getElementById("video-list");
 const toastEl = document.getElementById("toast");
+const stopButton = document.getElementById("stop-button");
 
 function showToast(message, type = "info") {
   toastEl.textContent = message;
@@ -80,6 +81,26 @@ async function playVideo(id, name) {
     console.error(err);
     showToast(err.message, "error");
   }
+}
+
+async function stopPlayback() {
+  try {
+    const response = await fetch("/api/stop", { method: "POST" });
+
+    if (!response.ok) {
+      const payload = await response.json().catch(() => ({}));
+      throw new Error(payload.error || `Unable to stop playback (${response.status})`);
+    }
+
+    showToast("Returning to default loop");
+  } catch (err) {
+    console.error(err);
+    showToast(err.message, "error");
+  }
+}
+
+if (stopButton) {
+  stopButton.addEventListener("click", stopPlayback);
 }
 
 fetchVideos();

--- a/static/style.css
+++ b/static/style.css
@@ -23,6 +23,12 @@ header {
   margin-bottom: 2rem;
 }
 
+.controls {
+  margin-top: 1.25rem;
+  display: flex;
+  justify-content: center;
+}
+
 h1 {
   margin: 0;
   font-size: clamp(2.25rem, 4vw, 3rem);
@@ -109,6 +115,24 @@ p {
 .play-button:hover {
   transform: translateY(-2px);
   box-shadow: 0 12px 28px rgba(120, 75, 160, 0.5);
+}
+
+.stop-button {
+  background: transparent;
+  border: 2px solid rgba(255, 90, 90, 0.75);
+  color: #ffbcbc;
+  font-weight: 600;
+  border-radius: 999px;
+  padding: 0.5rem 1.4rem;
+  cursor: pointer;
+  transition: transform 120ms ease, box-shadow 120ms ease, background-color 120ms ease;
+}
+
+.stop-button:focus,
+.stop-button:hover {
+  background: rgba(255, 90, 90, 0.12);
+  box-shadow: 0 8px 20px rgba(255, 90, 90, 0.25);
+  transform: translateY(-2px);
 }
 
 #toast {

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,6 +11,9 @@
       <header>
         <h1>Music Video Selector</h1>
         <p>Choose a video to play on the stage screen.</p>
+        <div class="controls">
+          <button type="button" id="stop-button" class="stop-button">Stop</button>
+        </div>
       </header>
       <section id="video-list" class="video-grid" aria-live="polite"></section>
     </main>


### PR DESCRIPTION
## Summary
- ensure the playback controller always restarts the default loop when playback stops and expose a stop API endpoint
- add a stop button in the UI and wire it to the new endpoint with basic styling

## Testing
- python -m compileall app.py

------
https://chatgpt.com/codex/tasks/task_e_68ddc76a57ec8332a4a40ef7f96d3442