### PR TITLE
Fix invalid regex in builder path normalization

### DIFF
--- a/DMX Template Builder/builder.js
+++ b/DMX Template Builder/builder.js
@@ -391,7 +391,7 @@ function exportTemplate(preparedActions, options = {}) {
 function normalizeBasePath(value) {
   if (!value) return "";
   if (value === "/") return "";
-  return value.replace(/\/+$, "");
+  return value.replace(/\/+$/, "");
 }
 
 function buildApiUrl(base, path) {


### PR DESCRIPTION
## Summary
- fix the export base path normalization regex so the DMX Template Builder loads without a syntax error

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68def3f5979883329ae8d0ad608d6787