### PR TITLE
Add live preview mode and video time capture to DMX builder

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -95,6 +95,17 @@ body {
   background: var(--accent-dark);
 }
 
+.toggle-button[aria-pressed="true"] {
+  background: var(--accent);
+  border-color: transparent;
+  color: #111827;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+}
+
+.toggle-button[aria-pressed="true"]:not(:disabled):hover {
+  background: var(--accent-dark);
+}
+
 .secondary {
   background: transparent;
 }

--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -20,6 +20,15 @@
         </select>
       </label>
       <button id="add-row" type="button" class="control-button" disabled>Add Step</button>
+      <button
+        id="preview-mode-toggle"
+        type="button"
+        class="control-button toggle-button"
+        aria-pressed="false"
+        disabled
+      >
+        Preview Mode: Off
+      </button>
       <button id="sort-rows" type="button" class="control-button" disabled>Sort by Time</button>
       <button id="save-template" type="button" class="primary" disabled>Save Template</button>
       <button id="export-template" type="button" class="secondary" disabled>Export JSON</button>


### PR DESCRIPTION
## Summary
- add a preview mode toggle to the DMX template builder that syncs new cues with the current video time
- wire preview mode to a new backend API so the Raspberry Pi outputs DMX data in real time while editing
- update DMX manager logic to generate a preview universe state that resumes from the chosen video timestamp

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68defc4e370c8332b7a69a7b56512609