### PR TITLE
Improve preview toggle feedback

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -106,6 +106,12 @@ body {
   background: var(--accent-dark);
 }
 
+.toggle-button.is-busy {
+  cursor: progress;
+  opacity: 0.7;
+  pointer-events: none;
+}
+
 .secondary {
   background: transparent;
 }

--- a/DMX Template Builder/builder.js
+++ b/DMX Template Builder/builder.js
@@ -10,6 +10,13 @@ const videoEl = document.getElementById("preview-video");
 const previewToggle = document.getElementById("preview-mode-toggle");
 const rowTemplate = document.getElementById("action-row-template");
 
+const PREVIEW_STATE_LABELS = {
+  on: "Preview Mode: On",
+  off: "Preview Mode: Off",
+  enabling: "Enabling Preview Mode…",
+  disabling: "Disabling Preview Mode…",
+};
+
 let videos = [];
 let currentVideo = null;
 let actions = [];
@@ -70,7 +77,7 @@ async function handlePreviewToggle() {
     return;
   }
   if (previewToggle) {
-    previewToggle.disabled = true;
+    setPreviewToggleBusy(true, !previewMode);
   }
   try {
     if (previewMode) {
@@ -80,7 +87,7 @@ async function handlePreviewToggle() {
     }
   } finally {
     if (previewToggle) {
-      previewToggle.disabled = false;
+      setPreviewToggleBusy(false);
     }
   }
 }
@@ -129,7 +136,27 @@ function updatePreviewToggle(active) {
   const isActive = Boolean(active);
   previewToggle.setAttribute("aria-pressed", isActive ? "true" : "false");
   previewToggle.classList.toggle("is-active", isActive);
-  previewToggle.textContent = isActive ? "Preview Mode: On" : "Preview Mode: Off";
+  previewToggle.classList.remove("is-busy");
+  previewToggle.disabled = false;
+  const label = isActive ? PREVIEW_STATE_LABELS.on : PREVIEW_STATE_LABELS.off;
+  previewToggle.textContent = label;
+  previewToggle.setAttribute("title", label);
+}
+
+function setPreviewToggleBusy(isBusy, targetEnabledState) {
+  if (!previewToggle) return;
+  const shouldEnable = Boolean(targetEnabledState);
+  previewToggle.classList.toggle("is-busy", Boolean(isBusy));
+  previewToggle.disabled = Boolean(isBusy);
+  if (isBusy) {
+    const label = shouldEnable
+      ? PREVIEW_STATE_LABELS.enabling
+      : PREVIEW_STATE_LABELS.disabling;
+    previewToggle.textContent = label;
+    previewToggle.setAttribute("title", label);
+    return;
+  }
+  updatePreviewToggle(previewMode);
 }
 
 function queuePreviewSync() {


### PR DESCRIPTION
## Summary
- add explicit busy-state labels so the preview toggle reflects enabling/disabling progress
- ensure the preview toggle resets its disabled state after preview requests finish
- style the toggle button while busy to communicate that preview mode is switching

## Testing
- Not run (UI changes only)


------
https://chatgpt.com/codex/tasks/task_e_68df005365348332bce834c15279340d