### PR TITLE
Auto-sort cue table and remove manual sort control

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -426,6 +426,52 @@ body {
   opacity: 0.75;
 }
 
+.channel-status {
+  margin-top: 0.75rem;
+  padding: 0.75rem 0.9rem;
+  background: rgba(30, 41, 59, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.6rem;
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
+}
+
+.channel-status__title {
+  margin: 0 0 0.5rem;
+  font-size: 0.85rem;
+  font-weight: 600;
+  letter-spacing: 0.03em;
+  text-transform: uppercase;
+  opacity: 0.75;
+}
+
+.channel-status__content {
+  font-size: 0.95rem;
+  line-height: 1.4;
+}
+
+.channel-status__list {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.channel-status__item {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.channel-status__item-label {
+  font-weight: 600;
+}
+
+.channel-status__empty {
+  margin: 0;
+  opacity: 0.75;
+}
+
 .table-wrapper {
   overflow: auto;
 }
@@ -445,6 +491,14 @@ body {
   padding: 0.5rem 0.6rem;
   text-align: left;
   border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+}
+
+.actions-table tbody tr.is-active {
+  background: rgba(129, 140, 248, 0.12);
+}
+
+.actions-table tbody tr.is-active td {
+  border-bottom-color: rgba(129, 140, 248, 0.4);
 }
 
 .actions-table td input,

--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -41,7 +41,6 @@
       >
         Preview Mode: Off
       </button>
-      <button id="sort-rows" type="button" class="control-button" disabled>Sort by Time</button>
       <button id="save-template" type="button" class="primary" disabled>Save Template</button>
       <button id="export-template" type="button" class="secondary" disabled>Export JSON</button>
       <span id="status-message" role="status" aria-live="polite"></span>
@@ -72,6 +71,17 @@
       <section class="preview-panel">
         <h2>Video Preview</h2>
         <video id="preview-video" controls preload="metadata"></video>
+        <section
+          id="channel-status"
+          class="channel-status"
+          aria-live="polite"
+          aria-label="Active channels"
+        >
+          <h3 class="channel-status__title">Active Channels</h3>
+          <div id="channel-status-list" class="channel-status__content">
+            <p class="channel-status__empty">All channels at blackout.</p>
+          </div>
+        </section>
         <div class="video-hints">
           <p>
             Select a row in the table to jump to that cue. The time input keeps the


### PR DESCRIPTION
## Summary
- remove the manual "Sort by Time" control from the template builder toolbar
- assign stable local identifiers to cue rows and automatically sort the action list whenever it renders
- keep focus and video sync aligned with the reordered row when its timestamp changes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68df5306d6b08332a8453a97ea13e9eb