### PR TITLE
Add bottom playback bar with volume slider

### DIFF
--- a/static/app.js
+++ b/static/app.js
@@ -1,7 +1,22 @@
 const template = document.getElementById("video-card-template");
 const listEl = document.getElementById("video-list");
 const toastEl = document.getElementById("toast");
-const stopButton = document.getElementById("stop-button");
+const playerBar = document.getElementById("player-bar");
+const playerStatusEl = document.querySelector(".player-status");
+const playerTitleEl = document.querySelector(".player-title");
+const playerArtworkEl = document.querySelector(".player-artwork");
+const playerProgressEl = document.querySelector(".player-progress");
+const progressFillEl = document.querySelector(".player-progress-fill");
+const currentTimeEl = document.querySelector(".player-time-current");
+const totalTimeEl = document.querySelector(".player-time-total");
+const volumeSlider = document.getElementById("volume-slider");
+const playerStopButton = document.getElementById("player-stop-button");
+
+let isFetchingStatus = false;
+let statusPollTimer = null;
+let isVolumeInteracting = false;
+let volumeUpdateTimer = null;
+let pendingVolumeValue = null;
 
 function showToast(message, type = "info") {
   toastEl.textContent = message;
@@ -77,6 +92,7 @@ async function playVideo(id, name) {
     }
 
     showToast(`Playing ${name}`);
+    fetchStatus();
   } catch (err) {
     console.error(err);
     showToast(err.message, "error");
@@ -93,14 +109,185 @@ async function stopPlayback() {
     }
 
     showToast("Returning to default loop");
+    fetchStatus();
   } catch (err) {
     console.error(err);
     showToast(err.message, "error");
   }
 }
 
-if (stopButton) {
-  stopButton.addEventListener("click", stopPlayback);
+function formatTime(seconds) {
+  if (!Number.isFinite(seconds) || seconds < 0) {
+    return "0:00";
+  }
+  const totalSeconds = Math.floor(seconds);
+  const minutes = Math.floor(totalSeconds / 60);
+  const secs = totalSeconds % 60;
+  return `${minutes}:${secs.toString().padStart(2, "0")}`;
+}
+
+function updatePlayerUI(status) {
+  if (!playerBar || !status) {
+    return;
+  }
+
+  const isVideo = status.mode === "video" && status.video;
+  playerBar.classList.toggle("is-default", !isVideo);
+
+  if (playerStatusEl) {
+    playerStatusEl.textContent = isVideo ? "Now playing" : "Default loop active";
+  }
+
+  if (playerTitleEl) {
+    if (isVideo) {
+      playerTitleEl.textContent = status.video.name || "Playing";
+    } else {
+      playerTitleEl.textContent = "Stage screen is showing the loop.";
+    }
+  }
+
+  if (playerArtworkEl) {
+    if (isVideo && status.video.poster) {
+      playerArtworkEl.style.backgroundImage = `url(${status.video.poster})`;
+      playerArtworkEl.classList.remove("is-placeholder");
+    } else if (isVideo) {
+      playerArtworkEl.style.backgroundImage = "";
+      playerArtworkEl.classList.add("is-placeholder");
+    } else {
+      playerArtworkEl.style.backgroundImage = "";
+      playerArtworkEl.classList.remove("is-placeholder");
+    }
+  }
+
+  const duration = Number.isFinite(status.duration) ? status.duration : null;
+  const position = Number.isFinite(status.position) ? Math.max(0, status.position) : 0;
+
+  if (playerProgressEl) {
+    const percent = duration && duration > 0 ? Math.min(100, (position / duration) * 100) : 0;
+    playerProgressEl.setAttribute("aria-valuenow", percent.toFixed(1));
+    playerProgressEl.setAttribute(
+      "aria-valuetext",
+      duration ? `${formatTime(position)} of ${formatTime(duration)}` : ""
+    );
+    if (progressFillEl) {
+      progressFillEl.style.width = `${percent}%`;
+    }
+  }
+
+  if (currentTimeEl) {
+    currentTimeEl.textContent = duration ? formatTime(position) : "0:00";
+  }
+
+  if (totalTimeEl) {
+    totalTimeEl.textContent = duration ? formatTime(duration) : "0:00";
+  }
+
+  if (volumeSlider) {
+    const volume = Number.isFinite(status.volume) ? Math.max(0, Math.min(100, status.volume)) : null;
+    volumeSlider.disabled = !isVideo;
+    if (volume !== null && !isVolumeInteracting) {
+      volumeSlider.value = String(Math.round(volume));
+    }
+  }
+
+  if (playerStopButton) {
+    playerStopButton.disabled = !isVideo;
+  }
+}
+
+async function fetchStatus() {
+  if (isFetchingStatus) {
+    return;
+  }
+  isFetchingStatus = true;
+  try {
+    const response = await fetch("/api/status");
+    if (!response.ok) {
+      throw new Error(`Status request failed (${response.status})`);
+    }
+    const payload = await response.json();
+    updatePlayerUI(payload);
+  } catch (err) {
+    console.error(err);
+  } finally {
+    isFetchingStatus = false;
+  }
+}
+
+function scheduleStatusPolling() {
+  if (statusPollTimer) {
+    clearInterval(statusPollTimer);
+  }
+  statusPollTimer = setInterval(fetchStatus, 1000);
+}
+
+function scheduleVolumeUpdate(value) {
+  if (!volumeSlider || volumeSlider.disabled) {
+    return;
+  }
+
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric)) {
+    return;
+  }
+
+  pendingVolumeValue = Math.max(0, Math.min(100, numeric));
+
+  if (volumeUpdateTimer) {
+    clearTimeout(volumeUpdateTimer);
+  }
+
+  volumeUpdateTimer = setTimeout(() => {
+    volumeUpdateTimer = null;
+    if (pendingVolumeValue === null) {
+      return;
+    }
+    sendVolumeUpdate(pendingVolumeValue);
+  }, 180);
+}
+
+async function sendVolumeUpdate(value) {
+  pendingVolumeValue = null;
+  try {
+    const response = await fetch("/api/volume", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ volume: value }),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok) {
+      throw new Error(payload.error || `Unable to set volume (${response.status})`);
+    }
+    const returnedVolume = Number.isFinite(payload.volume) ? payload.volume : value;
+    if (volumeSlider && !isVolumeInteracting) {
+      volumeSlider.value = String(Math.round(Math.max(0, Math.min(100, returnedVolume))));
+    }
+  } catch (err) {
+    console.error(err);
+    showToast(err.message || "Unable to set volume", "error");
+  } finally {
+    fetchStatus();
+  }
+}
+
+if (playerStopButton) {
+  playerStopButton.addEventListener("click", stopPlayback);
+}
+
+if (volumeSlider) {
+  volumeSlider.addEventListener("input", (event) => {
+    isVolumeInteracting = true;
+    scheduleVolumeUpdate(event.target.value);
+  });
+  volumeSlider.addEventListener("change", (event) => {
+    isVolumeInteracting = false;
+    scheduleVolumeUpdate(event.target.value);
+  });
+  volumeSlider.addEventListener("blur", () => {
+    isVolumeInteracting = false;
+  });
 }
 
 fetchVideos();
+fetchStatus();
+scheduleStatusPolling();

--- a/static/style.css
+++ b/static/style.css
@@ -11,6 +11,7 @@ body {
   display: flex;
   justify-content: center;
   padding: 2rem;
+  padding-bottom: 8rem;
   box-sizing: border-box;
 }
 
@@ -163,4 +164,213 @@ p {
 
 #toast.error {
   background: rgba(120, 35, 35, 0.92);
+}
+
+.sr-only {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
+}
+
+.player-bar {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1.5rem;
+  align-items: center;
+  justify-content: space-between;
+  padding: 1.25rem 2rem;
+  background: rgba(10, 10, 12, 0.92);
+  backdrop-filter: blur(18px);
+  border-top: 1px solid rgba(255, 255, 255, 0.08);
+  box-shadow: 0 -14px 36px rgba(0, 0, 0, 0.45);
+  z-index: 10;
+}
+
+.player-bar .stop-button {
+  margin-left: 1rem;
+}
+
+.player-info {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+  min-width: min(320px, 100%);
+  flex: 1 1 280px;
+}
+
+.player-artwork {
+  width: 72px;
+  height: 72px;
+  border-radius: 16px;
+  background: rgba(255, 255, 255, 0.06);
+  background-position: center;
+  background-size: cover;
+  flex-shrink: 0;
+  box-shadow: 0 12px 24px rgba(0, 0, 0, 0.45);
+}
+
+.player-artwork.is-placeholder {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.72);
+  background: rgba(255, 255, 255, 0.08);
+}
+
+.player-artwork.is-placeholder::after {
+  content: "No artwork";
+}
+
+.player-bar.is-default .player-artwork {
+  display: none;
+}
+
+.player-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.player-status {
+  font-size: 0.9rem;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.player-title {
+  font-size: 1.1rem;
+  font-weight: 600;
+}
+
+.player-controls {
+  display: flex;
+  align-items: center;
+  gap: 1.5rem;
+  flex: 2 1 420px;
+  justify-content: flex-end;
+}
+
+.player-progress {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  min-width: 220px;
+}
+
+.player-bar.is-default .player-progress {
+  display: none;
+}
+
+.player-progress-track {
+  position: relative;
+  height: 6px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  overflow: hidden;
+}
+
+.player-progress-fill {
+  position: absolute;
+  left: 0;
+  top: 0;
+  bottom: 0;
+  width: 0%;
+  background: linear-gradient(90deg, #ff3cac, #784ba0, #2b86c5);
+  transition: width 200ms ease;
+}
+
+.player-time {
+  display: flex;
+  justify-content: space-between;
+  font-size: 0.9rem;
+  color: rgba(255, 255, 255, 0.7);
+}
+
+.player-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+}
+
+.player-bar.is-default .player-actions {
+  display: none;
+}
+
+.volume-slider {
+  -webkit-appearance: none;
+  width: 140px;
+  height: 4px;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.18);
+  outline: none;
+  cursor: pointer;
+  transition: background-color 120ms ease;
+}
+
+.volume-slider:hover,
+.volume-slider:focus {
+  background: rgba(255, 255, 255, 0.28);
+}
+
+.volume-slider::-webkit-slider-thumb {
+  -webkit-appearance: none;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ff3cac;
+  box-shadow: 0 0 0 4px rgba(255, 60, 172, 0.22);
+  transition: transform 120ms ease;
+}
+
+.volume-slider:active::-webkit-slider-thumb {
+  transform: scale(1.1);
+}
+
+.volume-slider::-moz-range-thumb {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  border: none;
+  background: #ff3cac;
+  box-shadow: 0 0 0 4px rgba(255, 60, 172, 0.22);
+  transition: transform 120ms ease;
+}
+
+.volume-slider:active::-moz-range-thumb {
+  transform: scale(1.1);
+}
+
+@media (max-width: 768px) {
+  body {
+    padding: 1.5rem 1.5rem 9rem;
+  }
+
+  .player-bar {
+    gap: 1rem;
+    padding: 1rem 1.5rem;
+  }
+
+  .player-controls {
+    flex-direction: column;
+    align-items: stretch;
+    gap: 1rem;
+  }
+
+  .volume-slider {
+    width: 100%;
+  }
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -11,9 +11,6 @@
       <header>
         <h1>Music Video Selector</h1>
         <p>Choose a video to play on the stage screen.</p>
-        <div class="controls">
-          <button type="button" id="stop-button" class="stop-button">Stop</button>
-        </div>
       </header>
       <section id="video-list" class="video-grid" aria-live="polite"></section>
     </main>
@@ -27,6 +24,44 @@
       </article>
     </template>
     <div id="toast" role="status" aria-live="assertive"></div>
+    <div id="player-bar" class="player-bar is-default" aria-live="polite">
+      <div class="player-info">
+        <div class="player-artwork" aria-hidden="true"></div>
+        <div class="player-text">
+          <span class="player-status">Default loop active</span>
+          <span class="player-title">Stage screen is showing the loop.</span>
+        </div>
+      </div>
+      <div class="player-controls">
+        <div
+          class="player-progress"
+          role="progressbar"
+          aria-valuemin="0"
+          aria-valuemax="100"
+          aria-valuenow="0"
+        >
+          <div class="player-progress-track">
+            <div class="player-progress-fill"></div>
+          </div>
+          <div class="player-time">
+            <span class="player-time-current">0:00</span>
+            <span class="player-time-total">0:00</span>
+          </div>
+        </div>
+        <div class="player-actions">
+          <input
+            type="range"
+            id="volume-slider"
+            class="volume-slider"
+            min="0"
+            max="100"
+            value="100"
+            aria-label="Volume"
+          />
+          <button type="button" id="player-stop-button" class="stop-button">Stop</button>
+        </div>
+      </div>
+    </div>
     <script src="/static/app.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add a fixed bottom player bar that exposes playback details, volume control, and stop control when a song is active
- expose playback status and volume endpoints backed by new controller helpers for querying and setting mpv state
- update the front-end to poll playback status, manage the new player UI, and remove the old stop control

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0032a15f48332afaac0b76d890b3c