### PR TITLE
Fix DMX sender to use bytes for OLA client

### DIFF
--- a/dmx.py
+++ b/dmx.py
@@ -140,7 +140,10 @@ class DMXOutput:
                 wrapper.Stop()
 
             with lock:
-                client.SendDmx(universe, data, _callback)
+                # python-ola expects a bytes-like object that implements ``tobytes``.
+                # ``bytearray`` does not provide that method, so we convert to
+                # ``bytes`` explicitly before sending to avoid AttributeError.
+                client.SendDmx(universe, bytes(data), _callback)
                 wrapper.Run()  # Blocks until wrapper.Stop() called in callback
             if not done.wait(timeout=1.0):
                 LOGGER.warning("Timed out waiting for DMX send confirmation")


### PR DESCRIPTION
## Summary
- convert DMX sender payload to bytes before passing to python-ola
- document why the conversion is needed to avoid AttributeError

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e0311fa3448332a16ef6e57fba9592