### PR TITLE
Add direct serial DMX output support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,6 +87,21 @@ A lightweight Flask application designed for a Raspberry Pi-powered music video 
 
    The app launches the default loop and exposes the control page at `http://<pi-ip-address>:666/`.
 
+## DMX output
+
+The controller can drive DMX fixtures either through [OLA](https://www.openlighting.org/ola/) or by writing directly to a USB-to-RS485 adapter such as an FT232RL+SP485 based cable.
+
+- **Using OLA (recommended):** Install the `python-ola` dependency along with the OLA daemon on your Raspberry Pi. Configure OLA to expose your USB or network DMX interface and the app will stream frames automatically.
+- **Direct USB cable support:** If you are using a simple FTDI USB-to-DMX interface, install `pyserial` and set the `DMX_SERIAL_PORT` environment variable before starting the app:
+
+  ```bash
+  pip install pyserial
+  export DMX_SERIAL_PORT=/dev/ttyUSB0  # adjust for your adapter path
+  python app.py
+  ```
+
+  The serial sender defaults to DMX512 timing (250000 baud, 8N2). You can fine tune the break and mark-after-break durations with `DMX_BREAK_DURATION` and `DMX_MARK_AFTER_BREAK` environment variables if your hardware requires different timings.
+
 ## Systemd service (optional)
 
 To start the controller automatically on boot, create `/etc/systemd/system/kpop-stage.service`:


### PR DESCRIPTION
## Summary
- add a serial DMX sender that can drive FTDI-based USB adapters when `DMX_SERIAL_PORT` is set
- make DMX frame timing adjustable via environment variables and fall back cleanly when the port is unavailable
- document how to configure DMX output, including direct USB cable usage

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68e035a7514083329c4a38a9f89e98c2