### PR TITLE
Default DMX universe to 0 and document override

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ A lightweight Flask application designed for a Raspberry Pi-powered music video 
 
 The controller can drive DMX fixtures either through [OLA](https://www.openlighting.org/ola/) or by writing directly to a USB-to-RS485 adapter such as an FT232RL+SP485 based cable.
 
-- **Using OLA (recommended):** Install the `python-ola` dependency along with the OLA daemon on your Raspberry Pi. Configure OLA to expose your USB or network DMX interface and the app will stream frames automatically.
+- **Using OLA (recommended):** Install the `python-ola` dependency along with the OLA daemon on your Raspberry Pi. Configure OLA to expose your USB or network DMX interface and the app will stream frames automatically. The app targets OLA universe `0` by default; set `DMX_UNIVERSE` in the environment if you need to use a different universe number.
 - **Direct USB cable support:** If you are using a simple FTDI USB-to-DMX interface, install `pyserial` and set the `DMX_SERIAL_PORT` environment variable before starting the app:
 
   ```bash

--- a/app.py
+++ b/app.py
@@ -518,7 +518,7 @@ class PlaybackController:
 app = Flask(__name__, static_folder="static", template_folder="templates")
 video_config = load_video_config(DATA_FILE)
 DEFAULT_VIDEO_PATH = resolve_media_path(video_config["default_video"])
-DMX_UNIVERSE = int(os.environ.get("DMX_UNIVERSE", "1"))
+DMX_UNIVERSE = int(os.environ.get("DMX_UNIVERSE", "0"))
 
 dmx_manager: DMXShowManager = create_manager(DMX_TEMPLATE_DIR, universe=DMX_UNIVERSE)
 controller = PlaybackController(

--- a/dmx.py
+++ b/dmx.py
@@ -111,7 +111,7 @@ class DMXAction:
 class DMXOutput:
     """Continuously pushes the latest DMX universe state to the hardware."""
 
-    def __init__(self, universe: int = 1, channel_count: int = DEFAULT_CHANNELS) -> None:
+    def __init__(self, universe: int = 0, channel_count: int = DEFAULT_CHANNELS) -> None:
         self.universe = universe
         self.channel_count = channel_count
         self._levels = [0] * self.channel_count
@@ -545,6 +545,6 @@ class DMXShowManager:
         tmp_path.replace(template_path)
 
 
-def create_manager(templates_dir: Path, universe: int = 1) -> DMXShowManager:
+def create_manager(templates_dir: Path, universe: int = 0) -> DMXShowManager:
     output = DMXOutput(universe=universe)
     return DMXShowManager(templates_dir, output)


### PR DESCRIPTION
## Summary
- default the DMX universe to 0 so OLA interfaces receive frames without extra configuration
- allow overriding via the DMX_UNIVERSE environment variable and document the behavior

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e045a3a84c8332a711af56df8bf872