### PR TITLE
Fix DMX serial logging and add regression tests

### DIFF
--- a/dmx.py
+++ b/dmx.py
@@ -269,7 +269,6 @@ class DMXOutput:
             )
             return None
 
-        LOGGER.info("Using DMX serial port %s for DMX output", port)
         serial_config: Dict[str, Any] = {
             "port": port,
             "baudrate": 250000,
@@ -302,6 +301,7 @@ class DMXOutput:
                     port,
                     exc_info=True,
                 )
+        LOGGER.info("Using DMX serial port %s for DMX output", port)
 
         thread_local = threading.local()
         lock = threading.Lock()

--- a/tests/test_dmx_serial_logging.py
+++ b/tests/test_dmx_serial_logging.py
@@ -1,0 +1,93 @@
+import logging
+import sys
+import types
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import dmx
+
+
+class _DummySerial:
+    def __init__(self, **kwargs):
+        self.kwargs = kwargs
+        self.break_condition = False
+        self.is_open = True
+        self.written = []
+
+    def close(self):
+        self.is_open = False
+
+    def write(self, payload):
+        self.written.append(payload)
+
+    def flush(self):
+        pass
+
+
+@pytest.fixture
+def serial_stub(monkeypatch):
+    stub = types.SimpleNamespace(
+        Serial=_DummySerial,
+        EIGHTBITS=8,
+        PARITY_NONE="N",
+        STOPBITS_TWO=2,
+    )
+    original = dmx.serial
+    monkeypatch.setattr(dmx, "serial", stub)
+    yield stub
+    monkeypatch.setattr(dmx, "serial", original)
+
+
+def _make_output(monkeypatch, caplog, **env):
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+    caplog.set_level(logging.DEBUG, logger=dmx.LOGGER.name)
+    caplog.clear()
+    output = dmx.DMXOutput()
+    return output
+
+
+def test_serial_info_logged_on_success(monkeypatch, caplog, serial_stub):
+    monkeypatch.delenv("DMX_SERIAL_NUMBER", raising=False)
+    output = _make_output(monkeypatch, caplog, DMX_SERIAL_PORT="/dev/test")
+    try:
+        messages = [record.getMessage() for record in caplog.records]
+        assert any(
+            "Using DMX serial port /dev/test for DMX output" in message
+            for message in messages
+        )
+    finally:
+        output.shutdown()
+        monkeypatch.delenv("DMX_SERIAL_PORT", raising=False)
+
+
+def test_serial_info_not_logged_on_failure(monkeypatch, caplog):
+    class _FailingSerial:
+        def __init__(self, **kwargs):
+            raise OSError("serial port missing")
+
+    stub = types.SimpleNamespace(
+        Serial=_FailingSerial,
+        EIGHTBITS=8,
+        PARITY_NONE="N",
+        STOPBITS_TWO=2,
+    )
+    monkeypatch.setattr(dmx, "serial", stub)
+
+    output = _make_output(monkeypatch, caplog, DMX_SERIAL_PORT="/dev/missing")
+    try:
+        messages = [record.getMessage() for record in caplog.records]
+        assert not any(
+            "Using DMX serial port /dev/missing for DMX output" in message
+            for message in messages
+        )
+        assert any(
+            "Unable to open DMX serial port /dev/missing" in message
+            for message in messages
+        )
+    finally:
+        output.shutdown()
+        monkeypatch.delenv("DMX_SERIAL_PORT", raising=False)


### PR DESCRIPTION
## Summary
- ensure the DMX serial port info log is emitted only after the port successfully opens
- add regression tests covering DMX serial logging for successful and failing connections

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e04af59eac8332bc6df8370c9b2bdd