### PR TITLE
Enable always-on live preview in DMX template builder

### DIFF
--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -32,15 +32,6 @@
         </select>
       </label>
       <button id="add-row" type="button" class="control-button" disabled>Add Step</button>
-      <button
-        id="preview-mode-toggle"
-        type="button"
-        class="control-button toggle-button"
-        aria-pressed="false"
-        disabled
-      >
-        Preview Mode: Off
-      </button>
       <button id="save-template" type="button" class="primary" disabled>Save Template</button>
       <button id="export-template" type="button" class="secondary" disabled>Export JSON</button>
       <span id="status-message" role="status" aria-live="polite"></span>


### PR DESCRIPTION
## Summary
- remove the preview mode toggle from the DMX template builder UI
- automatically start and maintain live preview sync whenever a song is selected, including auto-jumping updates
- refresh status messaging to reflect the always-on live preview workflow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e06229e36c83329bcff8ea3b760058