### PR TITLE
Add light template management and template sync fixes

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -31,6 +31,42 @@ body {
   justify-content: space-between;
 }
 
+.builder-tabs {
+  display: flex;
+  gap: 0.5rem;
+  padding: 0.75rem clamp(1rem, 3vw, 2.5rem);
+  background: #0f172a;
+  border-bottom: 1px solid rgba(255, 255, 255, 0.08);
+}
+
+.builder-tab {
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  background: transparent;
+  color: inherit;
+  border-radius: 0.45rem;
+  padding: 0.45rem 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.builder-tab:not(.is-active):hover {
+  background: rgba(255, 255, 255, 0.08);
+  transform: translateY(-1px);
+}
+
+.builder-tab.is-active {
+  background: var(--accent);
+  color: #111827;
+  border-color: transparent;
+  box-shadow: 0 0 0 2px rgba(255, 255, 255, 0.15);
+}
+
+.tab-panel[hidden] {
+  display: none;
+}
+
 .builder-header__content {
   flex: 1 1 20rem;
   min-width: 15rem;
@@ -175,6 +211,255 @@ body {
   display: flex;
   flex-direction: column;
   gap: 1.25rem;
+}
+
+.template-library {
+  padding: 1.25rem clamp(1rem, 3vw, 2.5rem);
+  background: rgba(15, 23, 42, 0.65);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  flex-direction: column;
+  gap: 1.5rem;
+}
+
+.template-library__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.template-library__header h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.3rem;
+}
+
+.template-library__header p {
+  margin: 0;
+  max-width: 40rem;
+  opacity: 0.75;
+  font-size: 0.95rem;
+}
+
+.template-library__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.template-library__list {
+  display: grid;
+  gap: 1rem;
+}
+
+.template-library__empty {
+  margin: 0;
+  opacity: 0.7;
+}
+
+.template-card {
+  background: rgba(17, 24, 39, 0.75);
+  border: 1px solid rgba(148, 163, 184, 0.3);
+  border-radius: 0.75rem;
+  padding: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.template-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.template-card__title-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.template-card__title {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.template-card__actions {
+  display: flex;
+  gap: 0.5rem;
+}
+
+.template-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.template-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.template-card__table {
+  width: 100%;
+  border-collapse: collapse;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.5rem;
+  overflow: hidden;
+}
+
+.template-card__table th,
+.template-card__table td {
+  padding: 0.6rem;
+  background: rgba(30, 41, 59, 0.65);
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+  text-align: left;
+}
+
+.template-card__table thead th {
+  background: rgba(79, 70, 229, 0.2);
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+}
+
+.template-card__table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.template-card__empty {
+  margin: 0;
+  text-align: center;
+  opacity: 0.7;
+  font-size: 0.9rem;
+}
+
+.template-row__tools {
+  display: flex;
+  gap: 0.4rem;
+}
+
+.template-card__footer {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.template-picker {
+  position: fixed;
+  inset: 0;
+  display: none;
+  align-items: center;
+  justify-content: center;
+  z-index: 50;
+}
+
+.template-picker.is-visible {
+  display: flex;
+}
+
+.template-picker__backdrop {
+  position: absolute;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.75);
+}
+
+.template-picker__dialog {
+  position: relative;
+  width: min(32rem, 90vw);
+  background: #0f172a;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  padding: 1.25rem;
+  box-shadow: 0 1.5rem 3rem rgba(15, 23, 42, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.template-picker__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 1rem;
+}
+
+.template-picker__header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.template-picker__close {
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1.5rem;
+  cursor: pointer;
+}
+
+.template-picker__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.template-picker__search input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.9);
+  color: inherit;
+}
+
+.template-picker__results {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  max-height: 18rem;
+  overflow-y: auto;
+}
+
+.template-picker__item {
+  display: flex;
+}
+
+.template-picker__option {
+  width: 100%;
+  padding: 0.6rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  background: rgba(30, 41, 59, 0.75);
+  color: inherit;
+  text-align: left;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.template-picker__option:hover,
+.template-picker__option:focus {
+  background: rgba(99, 102, 241, 0.35);
+  transform: translateY(-1px);
+}
+
+.template-picker__empty {
+  margin: 0;
+  opacity: 0.7;
+}
+
+.visually-hidden {
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  overflow: hidden;
+  clip: rect(0, 0, 0, 0);
+  white-space: nowrap;
+  border: 0;
 }
 
 .preset-settings__header {
@@ -511,23 +796,29 @@ body {
 
 .action-group-header.is-active td {
   border-bottom-color: rgba(129, 140, 248, 0.4);
+  background: rgba(129, 140, 248, 0.18);
 }
 
-.action-group-header__button {
+.action-group-header__content {
   display: flex;
   align-items: center;
-  gap: 0.6rem;
-  width: 100%;
+  gap: 0.75rem;
+}
+
+.action-group-header__toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
   background: none;
   border: none;
   color: inherit;
   font: inherit;
   cursor: pointer;
-  padding: 0.2rem 0.35rem;
+  padding: 0.25rem 0.4rem;
   border-radius: 0.45rem;
 }
 
-.action-group-header__button:focus-visible {
+.action-group-header__toggle:focus-visible {
   outline: 2px solid rgba(129, 140, 248, 0.6);
   outline-offset: 1px;
 }
@@ -539,14 +830,76 @@ body {
   width: 1.1rem;
 }
 
-.action-group-header__time {
-  flex: 1;
-  text-align: left;
+.action-group-header__label {
+  font-weight: 600;
+  letter-spacing: 0.01em;
+}
+
+.action-group-header__time-input {
+  width: 8.5rem;
+  padding: 0.35rem 0.4rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  background: rgba(15, 23, 42, 0.75);
+  color: inherit;
+  font: inherit;
+}
+
+.action-group-header__time-input:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.6);
+  outline-offset: 1px;
+}
+
+.action-group-header__actions {
+  margin-left: auto;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.75rem;
 }
 
 .action-group-header__count {
   font-weight: 500;
   opacity: 0.75;
+}
+
+.action-group-header__add-row {
+  padding: 0.35rem 0.6rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.75);
+  color: inherit;
+  cursor: pointer;
+}
+
+.action-group-header__add-row:hover {
+  background: rgba(129, 140, 248, 0.2);
+}
+
+.action-group-header__add-row:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.6);
+  outline-offset: 1px;
+}
+
+.action-group-header__time-input.invalid {
+  border-color: #f87171;
+  box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.5);
+}
+
+.action-group-header.is-drop-target td {
+  outline: 2px dashed rgba(129, 140, 248, 0.6);
+  outline-offset: -4px;
+}
+
+.action-group-item.is-dragging {
+  opacity: 0.6;
+}
+
+.action-group-item.drop-before td {
+  box-shadow: inset 0 2px 0 0 var(--accent);
+}
+
+.action-group-item.drop-after td {
+  box-shadow: inset 0 -2px 0 0 var(--accent);
 }
 
 .action-group-item td:first-child {
@@ -577,7 +930,7 @@ body {
 
 .preset-select {
   display: grid;
-  grid-template-columns: minmax(7rem, 1fr) minmax(5rem, auto);
+  grid-template-columns: minmax(7rem, 1fr) minmax(6rem, 1.5fr) minmax(4.5rem, auto);
   gap: 0.45rem;
   align-items: center;
 }
@@ -591,9 +944,72 @@ body {
   cursor: not-allowed;
 }
 
-.row-tools {
+.preset-select .value-slider {
+  width: 100%;
+  min-width: 0;
+  accent-color: var(--accent);
+  background: transparent;
+}
+
+.preset-select .value-slider:disabled {
+  opacity: 0.75;
+  cursor: not-allowed;
+}
+
+.row-tools,
+.template-row__tools {
   display: flex;
   gap: 0.5rem;
+}
+
+.action-group-header__add-template {
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+}
+
+.action-group-template {
+  background: rgba(59, 130, 246, 0.08);
+}
+
+.action-group-template__content {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  justify-content: space-between;
+}
+
+.action-group-template__title {
+  font-weight: 600;
+}
+
+.action-group-template__count {
+  opacity: 0.7;
+  font-size: 0.85rem;
+}
+
+.action-group-template__edit {
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: transparent;
+  color: inherit;
+  border-radius: 0.45rem;
+  padding: 0.4rem 0.75rem;
+  cursor: pointer;
+  transition: background 0.2s ease, transform 0.15s ease;
+}
+
+.action-group-template__edit:hover {
+  background: rgba(148, 163, 184, 0.15);
+  transform: translateY(-1px);
+}
+
+.action-group-item--template {
+  background: rgba(30, 64, 175, 0.12);
+}
+
+.timeline-empty {
+  padding: 1.5rem clamp(1rem, 3vw, 2.5rem);
+  text-align: center;
+  opacity: 0.75;
+  font-size: 0.95rem;
 }
 
 .row-tools button {

--- a/DMX Template Builder/builder.js
+++ b/DMX Template Builder/builder.js
@@ -1,5 +1,5 @@
 const videoSelect = document.getElementById("video-select");
-const addRowButton = document.getElementById("add-row");
+const addStepButton = document.getElementById("add-step");
 const saveButton = document.getElementById("save-template");
 const exportButton = document.getElementById("export-template");
 const statusEl = document.getElementById("status-message");
@@ -12,7 +12,21 @@ const channelStatusListEl = document.getElementById("channel-status-list");
 const addChannelPresetButton = document.getElementById("add-channel-preset");
 const channelPresetsSection = document.querySelector(".preset-settings");
 const builderLayout = document.querySelector(".builder-layout");
-const openChannelPresetsButton = document.getElementById("open-channel-presets");
+const tabButtons = Array.from(document.querySelectorAll(".builder-tab"));
+const tabPanels = Array.from(document.querySelectorAll("[data-tab-panel]"));
+const timelinePanel = document.getElementById("timeline-panel");
+const presetsPanel = document.getElementById("presets-panel");
+const templatesPanel = document.getElementById("templates-panel");
+const timelineEmptyState = document.getElementById("timeline-empty-state");
+const lightTemplatesContainer = document.getElementById("light-templates");
+const addLightTemplateButton = document.getElementById("add-light-template");
+const templatePickerEl = document.getElementById("template-picker");
+const templatePickerSearch = document.getElementById("template-picker-search");
+const templatePickerResults = document.getElementById("template-picker-results");
+const templatePickerCloseElements = Array.from(
+  document.querySelectorAll("[data-template-picker-close]"),
+);
+const templateRowTemplate = document.getElementById("template-row-template");
 
 let videos = [];
 let currentVideo = null;
@@ -24,16 +38,24 @@ let previewSyncHandle = null;
 let previewActivationPromise = null;
 let suppressPreviewPause = false;
 let channelPresets = [];
-let showingChannelPresets = true;
+let activeTab = "timeline";
 const collapsedChannelPresetIds = new Set();
-const collapsedTimeGroups = new Set();
-let renderedRows = [];
-let groupHeaderRows = new Map();
-let actionGroupTimes = [];
+const collapsedStepIds = new Set();
+let actionGroupIds = [];
+let stepInfoById = new Map();
+let draggingActionId = null;
 let lastKnownTimelineSeconds = 0;
+let lightTemplates = [];
+let templatePickerStepId = null;
+let templateInstanceCounter = 0;
+
+const TEMPLATE_INSTANCE_PROPERTY = "__templateInstanceId";
+const TEMPLATE_ROW_PROPERTY = "__templateRowId";
 
 const ACTION_ID_PROPERTY = "__actionLocalId";
 let actionIdCounter = 0;
+const STEP_ID_PROPERTY = "__stepLocalId";
+let stepIdCounter = 0;
 
 const API_BASE_CANDIDATES = [
   "/api",
@@ -44,6 +66,8 @@ const API_BASE_CANDIDATES = [
 
 const CHANNEL_PRESET_STORAGE_KEY = "dmxTemplateBuilder.channelPresets";
 
+const LIGHT_TEMPLATE_STORAGE_KEY = "dmxTemplateBuilder.lightTemplates";
+
 const DEFAULT_ACTION = Object.freeze({
   time: "00:00:00",
   channel: 1,
@@ -51,22 +75,30 @@ const DEFAULT_ACTION = Object.freeze({
   fade: 0,
   channelPresetId: null,
   valuePresetId: null,
+  templateId: null,
+  templateInstanceId: null,
+  templateRowId: null,
 });
 
 init();
 
 async function init() {
+  initTabs();
   try {
     await initChannelPresetsUI();
   } catch (error) {
     console.error("Unable to initialize channel presets", error);
   }
-  if (openChannelPresetsButton) {
-    openChannelPresetsButton.addEventListener("click", handleOpenChannelPresets);
+  try {
+    await initLightTemplatesUI();
+  } catch (error) {
+    console.error("Unable to initialize light templates", error);
   }
   loadVideos();
   videoSelect.addEventListener("change", handleVideoSelection);
-  addRowButton.addEventListener("click", handleAddRow);
+  if (addStepButton) {
+    addStepButton.addEventListener("click", handleAddStep);
+  }
   saveButton.addEventListener("click", handleSaveTemplate);
   exportButton.addEventListener("click", () => exportTemplate());
   if (videoEl) {
@@ -79,6 +111,49 @@ async function init() {
   updateWorkspaceVisibility();
 }
 
+function initTabs() {
+  if (!Array.isArray(tabButtons) || !tabButtons.length) {
+    return;
+  }
+  tabButtons.forEach((button) => {
+    if (!(button instanceof HTMLElement)) return;
+    button.addEventListener("click", () => {
+      const target = button.dataset.tab || "timeline";
+      setActiveTab(target);
+    });
+  });
+  updateTabSelection();
+}
+
+function updateTabSelection() {
+  tabButtons.forEach((button) => {
+    if (!(button instanceof HTMLElement)) return;
+    const target = button.dataset.tab || "timeline";
+    const isActive = target === activeTab;
+    button.classList.toggle("is-active", isActive);
+    button.setAttribute("aria-selected", isActive ? "true" : "false");
+    button.setAttribute("tabindex", isActive ? "0" : "-1");
+  });
+
+  tabPanels.forEach((panel) => {
+    if (!(panel instanceof HTMLElement)) return;
+    const target = panel.dataset.tabPanel || "timeline";
+    const isActive = target === activeTab;
+    panel.hidden = !isActive;
+    panel.setAttribute("aria-hidden", isActive ? "false" : "true");
+  });
+}
+
+function setActiveTab(tab) {
+  const normalized = tab || "timeline";
+  if (normalized === activeTab) {
+    return;
+  }
+  activeTab = normalized;
+  updateTabSelection();
+  updateWorkspaceVisibility();
+}
+
 function resetActionIdCounter() {
   actionIdCounter = 0;
 }
@@ -86,6 +161,82 @@ function resetActionIdCounter() {
 function generateActionId() {
   actionIdCounter += 1;
   return `action-${actionIdCounter}`;
+}
+
+function resetStepIdCounter() {
+  stepIdCounter = 0;
+}
+
+function generateStepId() {
+  stepIdCounter += 1;
+  return `step-${stepIdCounter}`;
+}
+
+function resetTemplateInstanceCounter() {
+  templateInstanceCounter = 0;
+}
+
+function seedTemplateInstanceCounter(list) {
+  resetTemplateInstanceCounter();
+  if (!Array.isArray(list)) {
+    return;
+  }
+  let maxValue = 0;
+  list.forEach((action) => {
+    const rawId = action?.templateInstanceId;
+    if (typeof rawId !== "string") return;
+    const match = rawId.match(/(\d+)$/);
+    if (!match) return;
+    const numeric = Number.parseInt(match[1], 10);
+    if (Number.isFinite(numeric)) {
+      maxValue = Math.max(maxValue, numeric);
+    }
+  });
+  if (maxValue > 0) {
+    templateInstanceCounter = maxValue;
+  }
+}
+
+function setActionStepId(action, stepId) {
+  if (!action || typeof action !== "object") {
+    return null;
+  }
+  const finalStepId = stepId || generateStepId();
+  if (Object.prototype.hasOwnProperty.call(action, STEP_ID_PROPERTY)) {
+    action[STEP_ID_PROPERTY] = finalStepId;
+  } else {
+    Object.defineProperty(action, STEP_ID_PROPERTY, {
+      value: finalStepId,
+      enumerable: false,
+      configurable: true,
+      writable: true,
+    });
+  }
+  return finalStepId;
+}
+
+function getActionStepId(action) {
+  if (!action || typeof action !== "object") {
+    return null;
+  }
+  if (Object.prototype.hasOwnProperty.call(action, STEP_ID_PROPERTY)) {
+    return action[STEP_ID_PROPERTY];
+  }
+  return setActionStepId(action);
+}
+
+function assignStepIdsForActions(list) {
+  resetStepIdCounter();
+  const timeToStep = new Map();
+  list.forEach((action) => {
+    const timeKey = action.time || DEFAULT_ACTION.time;
+    let stepId = timeToStep.get(timeKey);
+    if (!stepId) {
+      stepId = generateStepId();
+      timeToStep.set(timeKey, stepId);
+    }
+    setActionStepId(action, stepId);
+  });
 }
 
 function ensureActionLocalId(action) {
@@ -109,9 +260,18 @@ function getActionLocalId(action) {
 
 function describeFocusedActionField(element) {
   if (!element || !element.dataset) return null;
-  const { actionId, field } = element.dataset;
-  if (!actionId || !field) return null;
-  const descriptor = { actionId, field };
+  const { actionId, groupId, field } = element.dataset;
+  if (!field) return null;
+  if (groupId) {
+    const descriptor = { kind: "group", groupId, field };
+    if (typeof element.selectionStart === "number" && typeof element.selectionEnd === "number") {
+      descriptor.selectionStart = element.selectionStart;
+      descriptor.selectionEnd = element.selectionEnd;
+    }
+    return descriptor;
+  }
+  if (!actionId) return null;
+  const descriptor = { kind: "action", actionId, field };
   if (typeof element.selectionStart === "number" && typeof element.selectionEnd === "number") {
     descriptor.selectionStart = element.selectionStart;
     descriptor.selectionEnd = element.selectionEnd;
@@ -122,6 +282,30 @@ function describeFocusedActionField(element) {
 function focusActionField(descriptor) {
   if (!descriptor) return;
   if (!actionsBody) return;
+  if (descriptor.kind === "group") {
+    const { groupId, field } = descriptor;
+    if (!groupId || !field) return;
+    const selector = `[data-group-id="${groupId}"][data-field="${field}"]`;
+    const target = actionsBody.querySelector(selector);
+    if (!target) return;
+    try {
+      target.focus({ preventScroll: true });
+    } catch (error) {
+      target.focus();
+    }
+    if (
+      target instanceof HTMLInputElement &&
+      typeof descriptor.selectionStart === "number" &&
+      typeof descriptor.selectionEnd === "number"
+    ) {
+      try {
+        target.setSelectionRange(descriptor.selectionStart, descriptor.selectionEnd);
+      } catch (error) {
+        // Ignore selection errors.
+      }
+    }
+    return;
+  }
   const { actionId, field } = descriptor;
   if (!actionId || !field) return;
   const selector = `[data-action-id="${actionId}"][data-field="${field}"]`;
@@ -151,21 +335,17 @@ function setActionFieldMetadata(element, actionId, field) {
   element.dataset.field = field;
 }
 
-function handleAddRow() {
+function handleAddStep() {
   const time = getCurrentVideoTimecode();
-  addAction({ time });
-}
-
-function handleOpenChannelPresets() {
-  if (videoSelect.value) {
-    videoSelect.value = "";
-    handleVideoSelection();
-    return;
-  }
-  if (!showingChannelPresets) {
-    showingChannelPresets = true;
-    updateWorkspaceVisibility();
-  }
+  const stepId = generateStepId();
+  collapsedStepIds.delete(stepId);
+  addAction(
+    { time },
+    {
+      stepId,
+      focusDescriptor: { kind: "group", groupId: stepId, field: "step-time" },
+    },
+  );
 }
 
 function getCurrentVideoTimecode() {
@@ -398,9 +578,12 @@ function handleVideoSelection() {
   const videoId = videoSelect.value;
   if (!videoId) {
     currentVideo = null;
-    showingChannelPresets = true;
     actions = [];
     resetActionIdCounter();
+    resetStepIdCounter();
+    collapsedStepIds.clear();
+    stepInfoById.clear();
+    draggingActionId = null;
     templatePath = "";
     setControlsEnabled(false);
     renderActions();
@@ -410,17 +593,15 @@ function handleVideoSelection() {
     return;
   }
 
-  showingChannelPresets = false;
-  updateWorkspaceVisibility();
   currentVideo = videos.find((video) => video.id === videoId) || null;
   if (!currentVideo) {
     showStatus("Selected song could not be found.", "error");
     videoSelect.value = "";
-    showingChannelPresets = true;
     updateWorkspaceVisibility();
     return;
   }
 
+  updateWorkspaceVisibility();
   loadTemplate(videoId);
 }
 
@@ -436,9 +617,23 @@ async function loadTemplate(videoId) {
 
     const data = await response.json();
     resetActionIdCounter();
+    resetStepIdCounter();
+    collapsedStepIds.clear();
+    stepInfoById.clear();
+    draggingActionId = null;
     actions = (data.actions || []).map((action) => ({ ...DEFAULT_ACTION, ...action }));
     actions.forEach(ensureActionLocalId);
+    seedTemplateInstanceCounter(actions);
+    assignStepIdsForActions(actions);
     autoAssignPresetsToActions(actions);
+    const templateIds = new Set(
+      actions
+        .map((action) => action.templateId)
+        .filter((templateId) => typeof templateId === "string" && templateId),
+    );
+    templateIds.forEach((templateId) => {
+      syncTemplateInstances(templateId, { render: false });
+    });
     templatePath = data.video?.dmx_template || "";
     const videoUrl = data.video?.video_url || currentVideo?.video_url || "";
 
@@ -546,56 +741,92 @@ function renderActions(options = {}) {
     options.preserveFocus || describeFocusedActionField(document.activeElement);
 
   actions = sortActions(actions);
+  if (!actionsBody) return;
   actionsBody.innerHTML = "";
-  renderedRows = new Array(actions.length).fill(null);
-  actionGroupTimes = new Array(actions.length).fill(null);
-  groupHeaderRows = new Map();
+  actionGroupIds = new Array(actions.length).fill(null);
+  stepInfoById = new Map();
 
   if (!actions.length) {
     const emptyRow = document.createElement("tr");
     const cell = document.createElement("td");
     cell.colSpan = 5;
-    cell.innerHTML = '<div class="empty-state">No lighting steps yet. Use “Add Step” to begin.</div>';
+    cell.innerHTML = '<div class="empty-state">No steps yet. Use “Add Step” to begin.</div>';
     emptyRow.append(cell);
     actionsBody.append(emptyRow);
-    collapsedTimeGroups.clear();
+    collapsedStepIds.clear();
     updateActiveActionHighlight(lastKnownTimelineSeconds);
     return;
   }
 
-  const grouped = [];
+  const groupsInOrder = [];
+  const groupLookup = new Map();
+
   actions.forEach((action, index) => {
-    const timeKey = action.time || DEFAULT_ACTION.time;
-    actionGroupTimes[index] = timeKey;
-    const lastGroup = grouped[grouped.length - 1];
-    if (lastGroup && lastGroup.time === timeKey) {
-      lastGroup.items.push({ action, index });
-    } else {
-      grouped.push({ time: timeKey, items: [{ action, index }] });
+    const stepId = getActionStepId(action);
+    const timeValue = action.time || DEFAULT_ACTION.time;
+    actionGroupIds[index] = stepId;
+    let group = groupLookup.get(stepId);
+    if (!group) {
+      group = { id: stepId, time: timeValue, items: [] };
+      groupLookup.set(stepId, group);
+      groupsInOrder.push(group);
     }
+    if (!group.items.length) {
+      group.time = timeValue;
+    }
+    group.items.push({ action, index });
   });
 
-  const activeTimes = new Set();
+  groupsInOrder.forEach((group) => {
+    const indices = group.items.map((item) => item.index);
+    stepInfoById.set(group.id, {
+      id: group.id,
+      time: group.time,
+      indices,
+    });
+  });
 
-  grouped.forEach(({ time, items }) => {
-    activeTimes.add(time);
-    const collapsed = collapsedTimeGroups.has(time);
-    const headerRow = createGroupHeaderRow(time, items.length, collapsed);
-    groupHeaderRows.set(time, headerRow);
+  const activeGroups = new Set();
+
+  groupsInOrder.forEach((group) => {
+    activeGroups.add(group.id);
+    const collapsed = collapsedStepIds.has(group.id);
+    const headerRow = createGroupHeaderRow(group, collapsed);
     actionsBody.append(headerRow);
 
     if (!collapsed) {
-      items.forEach(({ action, index }) => {
-        const row = createActionRow(action, index, time);
-        renderedRows[index] = row;
+      const templateCounts = new Map();
+      group.items.forEach(({ action }) => {
+        if (action.templateInstanceId) {
+          const key = action.templateInstanceId;
+          templateCounts.set(key, (templateCounts.get(key) || 0) + 1);
+        }
+      });
+
+      let lastTemplateInstanceId = null;
+      group.items.forEach(({ action, index }) => {
+        if (action.templateId && action.templateInstanceId) {
+          if (action.templateInstanceId !== lastTemplateInstanceId) {
+            const bannerRow = createTemplateBannerRow(
+              group,
+              action,
+              templateCounts.get(action.templateInstanceId) || 0,
+            );
+            actionsBody.append(bannerRow);
+          }
+          lastTemplateInstanceId = action.templateInstanceId;
+        } else {
+          lastTemplateInstanceId = null;
+        }
+        const row = createActionRow(action, index, group);
         actionsBody.append(row);
       });
     }
   });
 
-  for (const time of [...collapsedTimeGroups]) {
-    if (!activeTimes.has(time)) {
-      collapsedTimeGroups.delete(time);
+  for (const stepId of [...collapsedStepIds]) {
+    if (!activeGroups.has(stepId)) {
+      collapsedStepIds.delete(stepId);
     }
   }
 
@@ -606,20 +837,32 @@ function renderActions(options = {}) {
   updateActiveActionHighlight();
 }
 
-function createGroupHeaderRow(time, count, collapsed) {
+function createGroupHeaderRow(group, collapsed) {
   const row = document.createElement("tr");
   row.className = "action-group-header";
-  row.dataset.groupTime = time;
+  row.dataset.groupId = group.id;
+  row.dataset.groupTime = group.time;
 
   const cell = document.createElement("td");
   cell.colSpan = 5;
 
-  const button = document.createElement("button");
-  button.type = "button";
-  button.className = "action-group-header__button";
-  button.setAttribute("aria-expanded", String(!collapsed));
-  button.dataset.groupTime = time;
-  button.addEventListener("click", () => toggleGroupCollapsed(time));
+  const content = document.createElement("div");
+  content.className = "action-group-header__content";
+
+  const toggleButton = document.createElement("button");
+  toggleButton.type = "button";
+  toggleButton.className = "action-group-header__toggle";
+  toggleButton.setAttribute("aria-expanded", String(!collapsed));
+  toggleButton.dataset.groupId = group.id;
+  toggleButton.addEventListener("click", () => toggleGroupCollapsed(group.id));
+  toggleButton.addEventListener("focus", () => {
+    const firstIndex = group.items[0]?.index;
+    if (Number.isInteger(firstIndex)) {
+      setHighlightedAction(firstIndex);
+    } else {
+      setHighlightedStep(group.id);
+    }
+  });
 
   const icon = document.createElement("span");
   icon.className = "action-group-header__icon";
@@ -627,39 +870,127 @@ function createGroupHeaderRow(time, count, collapsed) {
   icon.setAttribute("aria-hidden", "true");
 
   const label = document.createElement("span");
-  label.className = "action-group-header__time";
-  label.textContent = time;
+  label.className = "action-group-header__label";
+  label.textContent = "Step";
+
+  toggleButton.append(icon, label);
+
+  const timeInput = createInput({
+    type: "text",
+    value: group.time,
+    placeholder: "00:01:23",
+  });
+  timeInput.classList.add("action-group-header__time-input");
+  timeInput.dataset.groupId = group.id;
+  timeInput.dataset.field = "step-time";
+  timeInput.addEventListener("change", (event) => handleStepTimeChange(event, group.id));
+  timeInput.addEventListener("focus", () => {
+    const firstIndex = group.items[0]?.index;
+    if (Number.isInteger(firstIndex)) {
+      setHighlightedAction(firstIndex);
+    } else {
+      setHighlightedStep(group.id);
+    }
+  });
+
+  const actionsContainer = document.createElement("div");
+  actionsContainer.className = "action-group-header__actions";
 
   const countEl = document.createElement("span");
   countEl.className = "action-group-header__count";
-  countEl.textContent = `(${count})`;
+  const count = group.items.length;
+  countEl.textContent = `${count} row${count === 1 ? "" : "s"}`;
 
-  button.append(icon, label, countEl);
-  cell.append(button);
+  const addRowButton = document.createElement("button");
+  addRowButton.type = "button";
+  addRowButton.className = "action-group-header__add-row";
+  addRowButton.dataset.groupId = group.id;
+  addRowButton.textContent = "Add Row";
+  addRowButton.addEventListener("click", () => handleAddRowToGroup(group.id));
+  addRowButton.addEventListener("focus", () => setHighlightedStep(group.id));
+
+  const addTemplateButton = document.createElement("button");
+  addTemplateButton.type = "button";
+  addTemplateButton.className = "action-group-header__add-template";
+  addTemplateButton.dataset.groupId = group.id;
+  addTemplateButton.textContent = "Add Template";
+  addTemplateButton.addEventListener("click", () => handleAddTemplateToGroup(group.id));
+  addTemplateButton.addEventListener("focus", () => setHighlightedStep(group.id));
+
+  actionsContainer.append(countEl, addRowButton, addTemplateButton);
+
+  content.append(toggleButton, timeInput, actionsContainer);
+  cell.append(content);
   row.append(cell);
+
+  row.addEventListener("dragover", (event) => handleGroupHeaderDragOver(event, group.id));
+  row.addEventListener("dragleave", handleGroupHeaderDragLeave);
+  row.addEventListener("drop", (event) => handleGroupHeaderDrop(event, group.id));
 
   return row;
 }
 
-function createActionRow(action, index, groupTime) {
+function createTemplateBannerRow(group, action, count) {
+  const row = document.createElement("tr");
+  row.className = "action-group-template";
+  row.dataset.groupId = group.id;
+  if (action.templateInstanceId) {
+    row.dataset.templateInstanceId = action.templateInstanceId;
+  }
+
+  const cell = document.createElement("td");
+  cell.colSpan = 5;
+
+  const content = document.createElement("div");
+  content.className = "action-group-template__content";
+
+  const title = document.createElement("span");
+  title.className = "action-group-template__title";
+  const template = getLightTemplate(action.templateId);
+  title.textContent = template ? formatLightTemplateTitle(template) : "Template";
+
+  const countEl = document.createElement("span");
+  countEl.className = "action-group-template__count";
+  const total = Number.isFinite(count) ? count : group.items.length;
+  countEl.textContent = `${total} row${total === 1 ? "" : "s"}`;
+
+  const editButton = document.createElement("button");
+  editButton.type = "button";
+  editButton.className = "action-group-template__edit";
+  editButton.textContent = "Edit Template";
+  editButton.addEventListener("click", () => handleEditTemplateFromTimeline(action.templateId));
+
+  content.append(title, countEl, editButton);
+  cell.append(content);
+  row.append(cell);
+  return row;
+}
+
+function createActionRow(action, index, group) {
   const actionId = getActionLocalId(action);
   const row = rowTemplate.content.firstElementChild.cloneNode(true);
   row.dataset.actionIndex = String(index);
   row.dataset.actionId = actionId;
-  if (groupTime) {
-    row.dataset.groupTime = groupTime;
-    row.classList.add("action-group-item");
+  row.dataset.groupId = group.id;
+  row.dataset.groupTime = group.time;
+  row.classList.add("action-group-item");
+  if (action.templateInstanceId) {
+    row.dataset.templateInstanceId = action.templateInstanceId;
+    row.dataset.templateId = action.templateId || "";
+    row.dataset.templateRowId = action.templateRowId || "";
+    row.classList.add("action-group-item--template");
   }
+  row.draggable = true;
 
-  const timeInput = createInput({
-    type: "text",
-    value: action.time,
-    placeholder: "00:01:23",
+  row.addEventListener("focusin", () => {
+    setHighlightedAction(index);
+    seekToIndex(index);
   });
-  setActionFieldMetadata(timeInput, actionId, "time");
-  timeInput.addEventListener("change", (event) => handleTimeChange(event, index));
-  timeInput.addEventListener("focus", () => seekToIndex(index));
-  appendToColumn(row, "time", timeInput);
+  row.addEventListener("dragstart", handleRowDragStart);
+  row.addEventListener("dragend", handleRowDragEnd);
+  row.addEventListener("dragover", handleRowDragOver);
+  row.addEventListener("dragleave", handleRowDragLeave);
+  row.addEventListener("drop", handleRowDrop);
 
   const channelField = createChannelField(action, index, actionId);
   appendToColumn(row, "channel", channelField);
@@ -686,12 +1017,18 @@ function createActionRow(action, index, groupTime) {
   jumpButton.textContent = "Go";
   jumpButton.addEventListener("click", () => seekToIndex(index));
 
+  const duplicateButton = document.createElement("button");
+  duplicateButton.type = "button";
+  duplicateButton.className = "secondary";
+  duplicateButton.textContent = "Duplicate";
+  duplicateButton.addEventListener("click", () => duplicateAction(index));
+
   const removeButton = document.createElement("button");
   removeButton.type = "button";
   removeButton.textContent = "Delete";
   removeButton.addEventListener("click", () => removeAction(index));
 
-  tools.append(jumpButton, removeButton);
+  tools.append(jumpButton, duplicateButton, removeButton);
   if (toolsCell) {
     toolsCell.append(tools);
   }
@@ -699,16 +1036,16 @@ function createActionRow(action, index, groupTime) {
   return row;
 }
 
-function toggleGroupCollapsed(time) {
-  if (collapsedTimeGroups.has(time)) {
-    collapsedTimeGroups.delete(time);
+function toggleGroupCollapsed(stepId) {
+  if (collapsedStepIds.has(stepId)) {
+    collapsedStepIds.delete(stepId);
   } else {
-    collapsedTimeGroups.add(time);
+    collapsedStepIds.add(stepId);
   }
   renderActions();
-  const focusTarget = Array.from(
-    actionsBody.querySelectorAll(".action-group-header__button")
-  ).find((button) => button.dataset.groupTime === time);
+  const focusTarget = actionsBody.querySelector(
+    `.action-group-header__toggle[data-group-id="${stepId}"]`
+  );
   if (focusTarget) {
     try {
       focusTarget.focus({ preventScroll: true });
@@ -724,6 +1061,197 @@ function updateActiveActionHighlight(secondsOverride) {
   const index = findLatestActionIndexAtTime(seconds);
   setHighlightedAction(index);
   updateChannelStatusDisplay(seconds);
+}
+
+function handleGroupHeaderDragOver(event, stepId) {
+  if (!draggingActionId) return;
+  event.preventDefault();
+  const row = event.currentTarget;
+  row.classList.add("is-drop-target");
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = "move";
+  }
+}
+
+function handleGroupHeaderDragLeave(event) {
+  const row = event.currentTarget;
+  row.classList.remove("is-drop-target");
+}
+
+function handleGroupHeaderDrop(event, stepId) {
+  if (!draggingActionId) return;
+  event.preventDefault();
+  const row = event.currentTarget;
+  row.classList.remove("is-drop-target");
+  const groupInfo = stepInfoById.get(stepId);
+  const indices = groupInfo?.indices || [];
+  const insertionIndex = indices.length ? indices[indices.length - 1] + 1 : actions.length;
+  const targetTime = groupInfo?.time || DEFAULT_ACTION.time;
+  collapsedStepIds.delete(stepId);
+  clearAllDropIndicators();
+  placeActionAt(draggingActionId, insertionIndex, {
+    targetGroupId: stepId,
+    targetTime,
+  });
+  draggingActionId = null;
+}
+
+function handleRowDragStart(event) {
+  const row = event.currentTarget;
+  if (!(row instanceof HTMLElement)) return;
+  const actionId = row.dataset.actionId;
+  if (!actionId) return;
+  draggingActionId = actionId;
+  row.classList.add("is-dragging");
+  if (row.dataset.groupId) {
+    setHighlightedStep(row.dataset.groupId);
+  }
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = "move";
+    try {
+      event.dataTransfer.setData("text/plain", actionId);
+    } catch (error) {
+      // Ignore data transfer errors from unsupported browsers.
+    }
+  }
+}
+
+function handleRowDragEnd(event) {
+  const row = event.currentTarget;
+  if (row instanceof HTMLElement) {
+    row.classList.remove("is-dragging");
+  }
+  draggingActionId = null;
+  clearAllDropIndicators();
+}
+
+function handleRowDragOver(event) {
+  if (!draggingActionId) return;
+  event.preventDefault();
+  const row = event.currentTarget;
+  if (!(row instanceof HTMLElement)) return;
+  const rect = row.getBoundingClientRect();
+  const offset = event.clientY - rect.top;
+  const before = offset < rect.height / 2;
+  row.classList.toggle("drop-before", before);
+  row.classList.toggle("drop-after", !before);
+  if (event.dataTransfer) {
+    event.dataTransfer.dropEffect = "move";
+  }
+}
+
+function handleRowDragLeave(event) {
+  const row = event.currentTarget;
+  if (!(row instanceof HTMLElement)) return;
+  row.classList.remove("drop-before", "drop-after");
+}
+
+function handleRowDrop(event) {
+  if (!draggingActionId) return;
+  event.preventDefault();
+  const row = event.currentTarget;
+  if (!(row instanceof HTMLElement)) return;
+  const rect = row.getBoundingClientRect();
+  const before = event.clientY - rect.top < rect.height / 2;
+  const indexValue = Number.parseInt(row.dataset.actionIndex || "-1", 10);
+  if (!Number.isInteger(indexValue) || indexValue < 0) {
+    return;
+  }
+  row.classList.remove("drop-before", "drop-after");
+  clearAllDropIndicators();
+  const groupId = row.dataset.groupId || null;
+  const groupInfo = groupId ? stepInfoById.get(groupId) : null;
+  const insertionIndex = before ? indexValue : indexValue + 1;
+  const targetTime = groupInfo?.time || row.dataset.groupTime || DEFAULT_ACTION.time;
+  placeActionAt(draggingActionId, insertionIndex, {
+    targetGroupId: groupId,
+    targetTime,
+  });
+  draggingActionId = null;
+}
+
+function clearAllDropIndicators() {
+  if (!actionsBody) return;
+  actionsBody.querySelectorAll(".action-group-item").forEach((element) => {
+    element.classList.remove("drop-before", "drop-after", "is-dragging");
+  });
+  actionsBody.querySelectorAll(".action-group-header.is-drop-target").forEach((element) => {
+    element.classList.remove("is-drop-target");
+  });
+}
+
+function placeActionAt(actionId, insertionIndex, options = {}) {
+  const sourceIndex = actions.findIndex((item) => getActionLocalId(item) === actionId);
+  if (sourceIndex === -1) {
+    return;
+  }
+  const action = actions[sourceIndex];
+  const currentGroupId = getActionStepId(action);
+  actions.splice(sourceIndex, 1);
+
+  let targetIndex = Number.isInteger(insertionIndex) ? insertionIndex : actions.length;
+  if (sourceIndex < targetIndex) {
+    targetIndex -= 1;
+  }
+  if (targetIndex < 0) {
+    targetIndex = 0;
+  }
+  if (targetIndex > actions.length) {
+    targetIndex = actions.length;
+  }
+
+  const targetGroupId = options.targetGroupId || currentGroupId;
+  const finalGroupId = targetGroupId ? setActionStepId(action, targetGroupId) : getActionStepId(action);
+  const targetTime = options.targetTime || action.time || DEFAULT_ACTION.time;
+  action.time = secondsToTimecode(parseTimeString(targetTime) ?? parseTimeString(action.time) ?? 0);
+
+  actions.splice(targetIndex, 0, action);
+  renderActions();
+  const newIndex = actions.findIndex((item) => getActionLocalId(item) === actionId);
+  if (newIndex !== -1) {
+    setHighlightedAction(newIndex);
+  } else if (finalGroupId) {
+    setHighlightedStep(finalGroupId);
+  }
+  queuePreviewSync();
+}
+
+function setHighlightedStep(stepId) {
+  clearGroupHighlights();
+  if (!stepId) return;
+  highlightGroupById(stepId);
+}
+
+function clearGroupHighlights() {
+  if (!actionsBody) return;
+  actionsBody
+    .querySelectorAll(".action-group-header.is-active, .action-group-item.is-active")
+    .forEach((element) => {
+      element.classList.remove("is-active");
+    });
+}
+
+function highlightGroupById(stepId) {
+  if (!actionsBody) return;
+  actionsBody
+    .querySelectorAll(`[data-group-id="${stepId}"]`)
+    .forEach((element) => {
+      element.classList.add("is-active");
+    });
+}
+
+function setHighlightedAction(index) {
+  const normalizedIndex = Number.isInteger(index) && index >= 0 ? index : null;
+  if (normalizedIndex === null) {
+    clearGroupHighlights();
+    return;
+  }
+  const stepId = actionGroupIds[normalizedIndex];
+  if (!stepId) {
+    clearGroupHighlights();
+    return;
+  }
+  setHighlightedStep(stepId);
 }
 
 function resolveTimelineSeconds(secondsOverride) {
@@ -758,37 +1286,6 @@ function findLatestActionIndexAtTime(targetSeconds) {
     }
   });
   return bestIndex;
-}
-
-function setHighlightedAction(index) {
-  const normalizedIndex = Number.isInteger(index) && index >= 0 ? index : null;
-  groupHeaderRows.forEach((row) => {
-    row.classList.remove("is-active");
-  });
-  renderedRows.forEach((row) => {
-    if (row) {
-      row.classList.remove("is-active");
-    }
-  });
-
-  if (normalizedIndex === null) {
-    return;
-  }
-
-  const row = renderedRows[normalizedIndex];
-  if (row) {
-    row.classList.add("is-active");
-    return;
-  }
-
-  const groupTime = actionGroupTimes[normalizedIndex];
-  if (!groupTime) {
-    return;
-  }
-  const headerRow = groupHeaderRows.get(groupTime);
-  if (headerRow) {
-    headerRow.classList.add("is-active");
-  }
 }
 
 function updateChannelStatusDisplay(seconds) {
@@ -1066,6 +1563,15 @@ function createValueField(action, index, actionId) {
     select.value = "custom";
   }
 
+  const slider = createInput({
+    type: "range",
+    value: action.value,
+    min: 0,
+    max: 255,
+    step: 1,
+  });
+  slider.classList.add("value-slider");
+
   const input = createInput({
     type: "number",
     value: action.value,
@@ -1074,17 +1580,42 @@ function createValueField(action, index, actionId) {
     step: 1,
   });
   setActionFieldMetadata(input, actionId, "value");
-  input.addEventListener("change", (event) => handleValueNumberChange(event, index));
+  input.addEventListener("change", (event) => {
+    handleValueNumberChange(event, index);
+    slider.value = event.target.value;
+  });
+
+  slider.addEventListener("input", () => {
+    if (input.disabled) {
+      slider.value = input.value || "0";
+      return;
+    }
+    input.value = slider.value;
+  });
+
+  slider.addEventListener("change", () => {
+    if (input.disabled) {
+      slider.value = input.value || "0";
+      return;
+    }
+    const syntheticEvent = new Event("change", { bubbles: true });
+    input.dispatchEvent(syntheticEvent);
+  });
   if (selectedValuePreset) {
     input.value = selectedValuePreset.value;
+    slider.value = selectedValuePreset.value;
     input.disabled = true;
+    slider.disabled = true;
     input.title = "Value is set by preset";
+    slider.title = "Value is set by preset";
   } else {
     input.disabled = false;
+    slider.disabled = false;
     input.title = "";
+    slider.title = "";
   }
 
-  wrapper.append(select, input);
+  wrapper.append(select, slider, input);
   return wrapper;
 }
 
@@ -1095,38 +1626,77 @@ function appendToColumn(row, column, element) {
   }
 }
 
-function handleTimeChange(event, index) {
-  const value = event.target.value.trim();
+function handleStepTimeChange(event, stepId) {
+  const input = event.target;
+  const value = input.value.trim();
   const seconds = parseTimeString(value);
   if (seconds === null) {
-    event.target.classList.add("invalid");
-    event.target.setCustomValidity("Use HH:MM:SS format (seconds may include decimals).");
-    event.target.reportValidity();
+    input.classList.add("invalid");
+    input.setCustomValidity("Use HH:MM:SS format (seconds may include decimals).");
+    input.reportValidity();
     return;
   }
-  event.target.classList.remove("invalid");
-  event.target.setCustomValidity("");
+  input.classList.remove("invalid");
+  input.setCustomValidity("");
   const formatted = secondsToTimecode(seconds);
-  event.target.value = formatted;
-  const action = actions[index];
-  if (!action) {
-    queuePreviewSync();
-    return;
-  }
-  const actionId = getActionLocalId(action);
-  action.time = formatted;
+  input.value = formatted;
+
+  let updated = false;
+  actions.forEach((action) => {
+    if (getActionStepId(action) === stepId) {
+      action.time = formatted;
+      updated = true;
+    }
+  });
+
   const focusDescriptor = {
-    actionId,
-    field: "time",
-    selectionStart: event.target.selectionStart,
-    selectionEnd: event.target.selectionEnd,
+    kind: "group",
+    groupId: stepId,
+    field: "step-time",
+    selectionStart: input.selectionStart,
+    selectionEnd: input.selectionEnd,
   };
+
   renderActions({ preserveFocus: focusDescriptor });
-  const newIndex = actions.findIndex((item) => getActionLocalId(item) === actionId);
-  if (newIndex !== -1) {
-    seekToIndex(newIndex);
+
+  if (updated) {
+    const newIndex = actions.findIndex((item) => getActionStepId(item) === stepId);
+    if (newIndex !== -1) {
+      seekToIndex(newIndex);
+      return;
+    }
   }
+  setHighlightedStep(stepId);
   queuePreviewSync();
+}
+
+function handleAddRowToGroup(stepId) {
+  const groupInfo = stepInfoById.get(stepId);
+  const time = groupInfo?.time || DEFAULT_ACTION.time;
+  const insertIndex =
+    groupInfo && Array.isArray(groupInfo.indices) && groupInfo.indices.length
+      ? groupInfo.indices[groupInfo.indices.length - 1] + 1
+      : actions.length;
+  collapsedStepIds.delete(stepId);
+  addAction(
+    { time },
+    {
+      stepId,
+      insertIndex,
+      focusField: "channel",
+    },
+  );
+}
+
+function handleAddTemplateToGroup(stepId) {
+  collapsedStepIds.delete(stepId);
+  openTemplatePicker(stepId);
+}
+
+function handleEditTemplateFromTimeline(templateId) {
+  if (!templateId) return;
+  setActiveTab("templates");
+  renderLightTemplates({ focusTemplateId: templateId });
 }
 
 function handleNumberChange(event, index, key, min, max) {
@@ -1247,6 +1817,7 @@ function handleValuePresetChange(event, index) {
 function seekToIndex(index) {
   const action = actions[index];
   if (!action) return;
+  setHighlightedAction(index);
   const seconds = parseTimeString(action.time);
   if (seconds === null) return;
   updateActiveActionHighlight(seconds);
@@ -1259,12 +1830,26 @@ function seekToIndex(index) {
   queuePreviewSync();
 }
 
-function addAction(action) {
+function addAction(action, options = {}) {
   const newAction = { ...DEFAULT_ACTION, ...action };
   const actionId = getActionLocalId(newAction);
-  actions.push(newAction);
-  renderActions({ preserveFocus: { actionId, field: "time" } });
+  const stepId = setActionStepId(newAction, options.stepId);
+  const insertIndex =
+    Number.isInteger(options.insertIndex) && options.insertIndex >= 0
+      ? Math.min(options.insertIndex, actions.length)
+      : actions.length;
+  actions.splice(insertIndex, 0, newAction);
+
+  const focusDescriptor =
+    options.focusDescriptor ||
+    (options.focusField
+      ? { kind: "action", actionId, field: options.focusField }
+      : { kind: "action", actionId, field: "channel" });
+
+  renderActions({ preserveFocus: focusDescriptor });
+  setHighlightedStep(stepId);
   queuePreviewSync();
+  return { action: newAction, actionId, stepId };
 }
 
 function removeAction(index) {
@@ -1272,6 +1857,21 @@ function removeAction(index) {
   renderActions();
   showStatus("Removed cue.", "info");
   queuePreviewSync();
+}
+
+function duplicateAction(index) {
+  const original = actions[index];
+  if (!original) return;
+  const stepId = getActionStepId(original);
+  const copy = {
+    time: original.time,
+    channel: original.channel,
+    value: original.value,
+    fade: original.fade,
+    channelPresetId: original.channelPresetId,
+    valuePresetId: original.valuePresetId,
+  };
+  addAction(copy, { stepId, insertIndex: index + 1, focusField: "channel" });
 }
 
 function sortActions(list) {
@@ -1283,7 +1883,9 @@ function sortActions(list) {
 }
 
 function setControlsEnabled(enabled) {
-  addRowButton.disabled = !enabled;
+  if (addStepButton) {
+    addStepButton.disabled = !enabled;
+  }
   saveButton.disabled = !enabled;
   exportButton.disabled = !enabled;
 }
@@ -1561,21 +2163,41 @@ function renderChannelPresets() {
 
 function updateWorkspaceVisibility() {
   const hasSelectedSong = Boolean(currentVideo);
-  const presetsVisible = !hasSelectedSong && Boolean(showingChannelPresets);
+  const timelineActive = activeTab === "timeline";
+  const presetsActive = activeTab === "presets";
+  const templatesActive = activeTab === "templates";
 
   if (channelPresetsSection) {
-    channelPresetsSection.hidden = !presetsVisible;
-    channelPresetsSection.setAttribute("aria-hidden", presetsVisible ? "false" : "true");
+    const visible = presetsActive;
+    channelPresetsSection.hidden = !visible;
+    channelPresetsSection.setAttribute("aria-hidden", visible ? "false" : "true");
+  }
+
+  if (templatesPanel) {
+    const visible = templatesActive;
+    templatesPanel.hidden = !visible;
+    templatesPanel.setAttribute("aria-hidden", visible ? "false" : "true");
   }
 
   if (builderLayout) {
-    const builderVisible = hasSelectedSong;
-    builderLayout.hidden = !builderVisible;
-    builderLayout.setAttribute("aria-hidden", builderVisible ? "false" : "true");
+    const visible = timelineActive && hasSelectedSong;
+    builderLayout.hidden = !visible;
+    builderLayout.setAttribute("aria-hidden", visible ? "false" : "true");
   }
 
-  if (openChannelPresetsButton) {
-    openChannelPresetsButton.setAttribute("aria-pressed", presetsVisible ? "true" : "false");
+  if (templateInfoEl) {
+    if (!timelineActive) {
+      templateInfoEl.hidden = true;
+    }
+  }
+
+  if (timelinePanel) {
+    timelinePanel.setAttribute("aria-hidden", timelineActive ? "false" : "true");
+  }
+
+  if (timelineEmptyState) {
+    const showEmpty = timelineActive && !hasSelectedSong;
+    timelineEmptyState.hidden = !showEmpty;
   }
 }
 
@@ -1820,6 +2442,1073 @@ function sanitizeChannelValue(raw) {
   return { id, name, value };
 }
 
+function sanitizeLightTemplateRow(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const id = typeof raw.id === "string" && raw.id ? raw.id : generateId("templateRow");
+  const channelNumber = Number.parseInt(raw.channel, 10);
+  const channel = Number.isFinite(channelNumber) ? clamp(channelNumber, 1, 512) : 1;
+  const valueNumber = Number.parseInt(raw.value, 10);
+  const value = Number.isFinite(valueNumber) ? clamp(valueNumber, 0, 255) : 0;
+  const fadeNumber = Number.parseFloat(raw.fade);
+  const fade = Number.isFinite(fadeNumber) ? Math.max(0, Number(fadeNumber.toFixed(3))) : 0;
+  const channelPresetId =
+    typeof raw.channelPresetId === "string" && raw.channelPresetId ? raw.channelPresetId : null;
+  const valuePresetId =
+    typeof raw.valuePresetId === "string" && raw.valuePresetId ? raw.valuePresetId : null;
+  return { id, channel, value, fade, channelPresetId, valuePresetId };
+}
+
+function sanitizeLightTemplate(raw) {
+  if (!raw || typeof raw !== "object") return null;
+  const id = typeof raw.id === "string" && raw.id ? raw.id : generateId("template");
+  const name = typeof raw.name === "string" ? raw.name : "";
+  const rows = Array.isArray(raw.rows)
+    ? raw.rows.map((row) => sanitizeLightTemplateRow(row)).filter(Boolean)
+    : [];
+  return { id, name, rows };
+}
+
+function loadLightTemplatesFromLocalStorage() {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return [];
+  }
+  try {
+    const raw = window.localStorage.getItem(LIGHT_TEMPLATE_STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    if (!Array.isArray(parsed)) return [];
+    return parsed.map((item) => sanitizeLightTemplate(item)).filter(Boolean);
+  } catch (error) {
+    console.error("Unable to load light templates from local storage", error);
+    return [];
+  }
+}
+
+function saveLightTemplatesToLocalStorage(templates) {
+  if (typeof window === "undefined" || !window.localStorage) {
+    return;
+  }
+  try {
+    window.localStorage.setItem(LIGHT_TEMPLATE_STORAGE_KEY, JSON.stringify(templates));
+  } catch (error) {
+    console.error("Unable to cache light templates locally", error);
+  }
+}
+
+async function loadLightTemplates() {
+  const fallback = loadLightTemplatesFromLocalStorage();
+  try {
+    const { payload } = await fetchFromApiCandidates("/light-templates");
+    const templates = Array.isArray(payload?.templates) ? payload.templates : [];
+    const sanitized = templates.map((item) => sanitizeLightTemplate(item)).filter(Boolean);
+    saveLightTemplatesToLocalStorage(sanitized);
+    return sanitized;
+  } catch (error) {
+    console.error("Unable to load light templates from server", error);
+    return fallback;
+  }
+}
+
+function saveLightTemplates() {
+  const payload = buildLightTemplatePayload();
+  saveLightTemplatesToLocalStorage(payload);
+  persistLightTemplates(payload).catch((error) => {
+    console.error("Unable to save light templates", error);
+  });
+}
+
+function buildLightTemplatePayload() {
+  return lightTemplates.map((template) => ({
+    id: template.id,
+    name: template.name || "",
+    rows: Array.isArray(template.rows)
+      ? template.rows.map((row) => ({
+          id: row.id || generateId("templateRow"),
+          channel: clamp(Number.parseInt(row.channel, 10) || 1, 1, 512),
+          value: clamp(Number.parseInt(row.value, 10) || 0, 0, 255),
+          fade: Math.max(0, Number.parseFloat(row.fade) || 0),
+          channelPresetId:
+            typeof row.channelPresetId === "string" && row.channelPresetId
+              ? row.channelPresetId
+              : null,
+          valuePresetId:
+            typeof row.valuePresetId === "string" && row.valuePresetId
+              ? row.valuePresetId
+              : null,
+        }))
+      : [],
+  }));
+}
+
+async function persistLightTemplates(templates) {
+  const response = await fetchApi("/light-templates", {
+    method: "PUT",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ templates }),
+  });
+  if (!response.ok) {
+    throw new Error(`Request failed with status ${response.status}`);
+  }
+  try {
+    const payload = await response.json();
+    if (payload && Array.isArray(payload.templates)) {
+      const sanitized = payload.templates
+        .map((item) => sanitizeLightTemplate(item))
+        .filter(Boolean);
+      saveLightTemplatesToLocalStorage(sanitized);
+    }
+  } catch (error) {
+    console.error("Unable to parse light template save response", error);
+  }
+}
+
+function getLightTemplate(templateId) {
+  return lightTemplates.find((template) => template.id === templateId) || null;
+}
+
+function getTemplateRow(templateId, rowId) {
+  const template = getLightTemplate(templateId);
+  if (!template || !Array.isArray(template.rows)) return null;
+  return template.rows.find((row) => row.id === rowId) || null;
+}
+
+function createTemplateRowDefaults(overrides = {}) {
+  return {
+    id: overrides.id || generateId("templateRow"),
+    channel: clamp(Number.parseInt(overrides.channel, 10) || 1, 1, 512),
+    value: clamp(Number.parseInt(overrides.value, 10) || 0, 0, 255),
+    fade: Math.max(0, Number.parseFloat(overrides.fade) || 0),
+    channelPresetId:
+      typeof overrides.channelPresetId === "string" && overrides.channelPresetId
+        ? overrides.channelPresetId
+        : null,
+    valuePresetId:
+      typeof overrides.valuePresetId === "string" && overrides.valuePresetId
+        ? overrides.valuePresetId
+        : null,
+  };
+}
+
+function createLightTemplateDefaults(overrides = {}) {
+  const rows = Array.isArray(overrides.rows) && overrides.rows.length
+    ? overrides.rows.map((row) => sanitizeLightTemplateRow(row)).filter(Boolean)
+    : [createTemplateRowDefaults()];
+  return {
+    id: overrides.id || generateId("template"),
+    name: typeof overrides.name === "string" ? overrides.name : "",
+    rows,
+  };
+}
+
+async function initLightTemplatesUI() {
+  if (addLightTemplateButton) {
+    addLightTemplateButton.addEventListener("click", () => {
+      addLightTemplate();
+    });
+  }
+
+  templatePickerCloseElements.forEach((element) => {
+    element.addEventListener("click", () => closeTemplatePicker());
+  });
+
+  if (templatePickerEl) {
+    templatePickerEl.addEventListener("keydown", (event) => {
+      if (event.key === "Escape") {
+        event.preventDefault();
+        event.stopPropagation();
+        closeTemplatePicker();
+      }
+    });
+  }
+
+  if (templatePickerSearch) {
+    templatePickerSearch.addEventListener("input", () => {
+      renderTemplatePickerResults(templatePickerSearch.value || "");
+    });
+  }
+
+  lightTemplates = loadLightTemplatesFromLocalStorage();
+  renderLightTemplates();
+
+  lightTemplates = await loadLightTemplates();
+  renderLightTemplates();
+}
+
+function renderLightTemplates(options = {}) {
+  if (!lightTemplatesContainer) return;
+
+  const focusDescriptor =
+    options.preserveFocus || describeFocusedTemplateField(document.activeElement);
+
+  lightTemplatesContainer.innerHTML = "";
+
+  if (!lightTemplates.length) {
+    const empty = document.createElement("p");
+    empty.className = "template-library__empty";
+    empty.textContent = "No templates yet. Use “New Template” to create one.";
+    lightTemplatesContainer.append(empty);
+  } else {
+    lightTemplates.forEach((template) => {
+      const card = renderLightTemplateCard(template);
+      lightTemplatesContainer.append(card);
+    });
+  }
+
+  const query = templatePickerSearch ? templatePickerSearch.value || "" : "";
+  renderTemplatePickerResults(query);
+
+  if (options.focusTemplateId) {
+    const card = lightTemplatesContainer.querySelector(
+      `.template-card[data-template-id="${options.focusTemplateId}"]`,
+    );
+    if (card) {
+      const input = card.querySelector('[data-field="template-name"]');
+      if (input instanceof HTMLElement) {
+        try {
+          input.focus({ preventScroll: true });
+        } catch (error) {
+          input.focus();
+        }
+      }
+    }
+  } else if (focusDescriptor) {
+    focusTemplateField(focusDescriptor);
+  }
+}
+
+function describeFocusedTemplateField(element) {
+  if (!element || !(element instanceof HTMLElement)) return null;
+  const { templateId, rowId, field } = element.dataset || {};
+  if (!templateId || !field) return null;
+  const descriptor = { templateId, field };
+  if (rowId) {
+    descriptor.rowId = rowId;
+  }
+  if (
+    typeof element.selectionStart === "number" &&
+    typeof element.selectionEnd === "number"
+  ) {
+    descriptor.selectionStart = element.selectionStart;
+    descriptor.selectionEnd = element.selectionEnd;
+  }
+  return descriptor;
+}
+
+function focusTemplateField(descriptor) {
+  if (!descriptor || !lightTemplatesContainer) return;
+  const parts = [
+    `.template-card [data-template-id="${descriptor.templateId}"]`,
+    `[data-field="${descriptor.field}"]`,
+  ];
+  if (descriptor.rowId) {
+    parts.push(`[data-row-id="${descriptor.rowId}"]`);
+  }
+  const selector = parts.join("");
+  const target = lightTemplatesContainer.querySelector(selector);
+  if (!target) return;
+  try {
+    target.focus({ preventScroll: true });
+  } catch (error) {
+    target.focus();
+  }
+  if (
+    target instanceof HTMLInputElement &&
+    typeof descriptor.selectionStart === "number" &&
+    typeof descriptor.selectionEnd === "number"
+  ) {
+    try {
+      target.setSelectionRange(descriptor.selectionStart, descriptor.selectionEnd);
+    } catch (error) {
+      // Ignore selection errors for unsupported inputs.
+    }
+  }
+}
+
+function renderLightTemplateCard(template) {
+  const card = document.createElement("article");
+  card.className = "template-card";
+  card.dataset.templateId = template.id;
+
+  const header = document.createElement("header");
+  header.className = "template-card__header";
+
+  const titleGroup = document.createElement("div");
+  titleGroup.className = "template-card__title-group";
+
+  const title = document.createElement("h3");
+  title.className = "template-card__title";
+  title.textContent = formatLightTemplateTitle(template);
+  titleGroup.append(title);
+
+  const actionsEl = document.createElement("div");
+  actionsEl.className = "template-card__actions";
+
+  const duplicateButton = document.createElement("button");
+  duplicateButton.type = "button";
+  duplicateButton.className = "secondary";
+  duplicateButton.textContent = "Duplicate";
+  duplicateButton.addEventListener("click", () => duplicateLightTemplate(template.id));
+
+  const deleteButton = document.createElement("button");
+  deleteButton.type = "button";
+  deleteButton.className = "secondary";
+  deleteButton.textContent = "Delete";
+  deleteButton.addEventListener("click", () => removeLightTemplate(template.id));
+
+  actionsEl.append(duplicateButton, deleteButton);
+  header.append(titleGroup, actionsEl);
+
+  const body = document.createElement("div");
+  body.className = "template-card__body";
+
+  const nameField = document.createElement("label");
+  nameField.className = "template-field";
+
+  const nameLabel = document.createElement("span");
+  nameLabel.textContent = "Name";
+
+  const nameInput = document.createElement("input");
+  nameInput.type = "text";
+  nameInput.value = template.name || "";
+  nameInput.placeholder = "Front light strobe white";
+  nameInput.dataset.templateId = template.id;
+  nameInput.dataset.field = "template-name";
+  nameInput.addEventListener("input", (event) => handleTemplateNameInput(template.id, event));
+
+  nameField.append(nameLabel, nameInput);
+  body.append(nameField);
+
+  const table = createTemplateRowsTable(template);
+  body.append(table);
+
+  const footer = document.createElement("div");
+  footer.className = "template-card__footer";
+
+  const addRowButton = document.createElement("button");
+  addRowButton.type = "button";
+  addRowButton.className = "secondary";
+  addRowButton.textContent = "Add Row";
+  addRowButton.addEventListener("click", () => addRowToLightTemplate(template.id));
+
+  footer.append(addRowButton);
+  body.append(footer);
+
+  card.append(header, body);
+  return card;
+}
+
+function updateLightTemplateCardTitle(card, template) {
+  if (!card) return;
+  const title = card.querySelector(".template-card__title");
+  if (title) {
+    title.textContent = formatLightTemplateTitle(template);
+  }
+}
+
+function formatLightTemplateTitle(template) {
+  if (template.name) {
+    return template.name;
+  }
+  return "Untitled Template";
+}
+
+function createTemplateRowsTable(template) {
+  const table = document.createElement("table");
+  table.className = "template-card__table";
+
+  const thead = document.createElement("thead");
+  const headRow = document.createElement("tr");
+  ["Row", "Channel", "Value", "Fade (s)", "Tools"].forEach((label) => {
+    const th = document.createElement("th");
+    th.scope = "col";
+    th.textContent = label;
+    headRow.append(th);
+  });
+  thead.append(headRow);
+  table.append(thead);
+
+  const tbody = document.createElement("tbody");
+  if (!template.rows.length) {
+    const emptyRow = document.createElement("tr");
+    const cell = document.createElement("td");
+    cell.colSpan = 5;
+    cell.className = "template-card__empty";
+    cell.textContent = "No rows yet. Add channels to this template.";
+    emptyRow.append(cell);
+    tbody.append(emptyRow);
+  } else {
+    template.rows.forEach((row, index) => {
+      const rowElement = createTemplateRowElement(template, row, index);
+      tbody.append(rowElement);
+    });
+  }
+
+  table.append(tbody);
+  return table;
+}
+
+function createTemplateRowElement(template, row, index) {
+  const baseRow = templateRowTemplate?.content?.firstElementChild
+    ? templateRowTemplate.content.firstElementChild.cloneNode(true)
+    : document.createElement("tr");
+
+  baseRow.dataset.templateId = template.id;
+  baseRow.dataset.rowId = row.id;
+  baseRow.classList.add("template-row");
+
+  const nameCell =
+    baseRow.querySelector('[data-template-column="name"]') || document.createElement("td");
+  nameCell.textContent = formatTemplateRowLabel(template, row, index);
+  baseRow.append(nameCell);
+
+  const channelCell =
+    baseRow.querySelector('[data-template-column="channel"]') || document.createElement("td");
+  channelCell.innerHTML = "";
+  const channelField = createTemplateChannelField(template.id, row);
+  channelCell.append(channelField);
+  baseRow.append(channelCell);
+
+  const valueCell =
+    baseRow.querySelector('[data-template-column="value"]') || document.createElement("td");
+  valueCell.innerHTML = "";
+  valueCell.append(createTemplateValueField(template.id, row));
+  baseRow.append(valueCell);
+
+  const fadeCell =
+    baseRow.querySelector('[data-template-column="fade"]') || document.createElement("td");
+  fadeCell.innerHTML = "";
+  const fadeInput = createInput({ type: "number", value: row.fade, min: 0, step: 0.1 });
+  fadeInput.dataset.templateId = template.id;
+  fadeInput.dataset.rowId = row.id;
+  fadeInput.dataset.field = "template-fade";
+  fadeInput.addEventListener("change", (event) =>
+    handleTemplateRowFadeChange(template.id, row.id, event),
+  );
+  fadeCell.append(fadeInput);
+  baseRow.append(fadeCell);
+
+  const toolsCell =
+    baseRow.querySelector('[data-template-column="tools"]') || document.createElement("td");
+  toolsCell.innerHTML = "";
+  const tools = document.createElement("div");
+  tools.className = "template-row__tools";
+
+  const duplicateButton = document.createElement("button");
+  duplicateButton.type = "button";
+  duplicateButton.className = "secondary";
+  duplicateButton.textContent = "Duplicate";
+  duplicateButton.addEventListener("click", () => duplicateTemplateRow(template.id, row.id));
+
+  const removeButton = document.createElement("button");
+  removeButton.type = "button";
+  removeButton.className = "secondary";
+  removeButton.textContent = "Delete";
+  removeButton.addEventListener("click", () => removeTemplateRow(template.id, row.id));
+
+  tools.append(duplicateButton, removeButton);
+  toolsCell.append(tools);
+  baseRow.append(toolsCell);
+
+  return baseRow;
+}
+
+function formatTemplateRowLabel(template, row, index) {
+  if (row.channelPresetId) {
+    const preset = getChannelPreset(row.channelPresetId);
+    if (preset) {
+      if (preset.name) {
+        return preset.name;
+      }
+      if (Number.isFinite(preset.channel)) {
+        return `Channel ${preset.channel}`;
+      }
+    }
+  }
+  return `Row ${index + 1}`;
+}
+
+function createTemplateChannelField(templateId, row) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "preset-select";
+
+  const select = document.createElement("select");
+  select.dataset.templateId = templateId;
+  select.dataset.rowId = row.id;
+  select.dataset.field = "template-channel-preset";
+  select.addEventListener("change", (event) =>
+    handleTemplateRowChannelPresetChange(templateId, row.id, event),
+  );
+
+  const customOption = document.createElement("option");
+  customOption.value = "";
+  customOption.textContent = "Custom…";
+  select.append(customOption);
+
+  const presets = getSortedChannelPresets();
+  let selectedPreset = null;
+  presets.forEach((preset) => {
+    const option = document.createElement("option");
+    option.value = preset.id;
+    option.dataset.channelPresetId = preset.id;
+    option.textContent = formatChannelPresetLabel(preset);
+    select.append(option);
+    if (preset.id === row.channelPresetId) {
+      selectedPreset = preset;
+    }
+  });
+
+  if (selectedPreset) {
+    select.value = selectedPreset.id;
+  } else {
+    select.value = "";
+  }
+
+  const input = createInput({ type: "number", value: row.channel, min: 1, max: 512, step: 1 });
+  input.dataset.templateId = templateId;
+  input.dataset.rowId = row.id;
+  input.dataset.field = "template-channel";
+  input.addEventListener("change", (event) =>
+    handleTemplateRowChannelInput(templateId, row.id, event),
+  );
+
+  if (selectedPreset && Number.isFinite(selectedPreset.channel)) {
+    input.value = clamp(Number.parseInt(selectedPreset.channel, 10) || 1, 1, 512);
+    input.disabled = true;
+    input.title = "Channel is set by preset";
+  } else {
+    input.disabled = false;
+    input.title = "";
+  }
+
+  wrapper.append(select, input);
+  return wrapper;
+}
+
+function createTemplateValueField(templateId, row) {
+  const wrapper = document.createElement("div");
+  wrapper.className = "preset-select";
+
+  const select = document.createElement("select");
+  select.dataset.templateId = templateId;
+  select.dataset.rowId = row.id;
+  select.dataset.field = "template-value-preset";
+  select.addEventListener("change", (event) =>
+    handleTemplateRowValuePresetChange(templateId, row.id, event),
+  );
+
+  const customOption = document.createElement("option");
+  customOption.value = "custom";
+  customOption.textContent = "Custom…";
+  select.append(customOption);
+
+  let channelPreset = null;
+  if (row.channelPresetId) {
+    channelPreset = getChannelPreset(row.channelPresetId);
+    if (!channelPreset) {
+      row.channelPresetId = null;
+      row.valuePresetId = null;
+    }
+  }
+
+  let selectedValuePreset = null;
+  const valuePresets = channelPreset ? channelPreset.values || [] : [];
+  valuePresets.forEach((valuePreset) => {
+    const option = document.createElement("option");
+    option.value = valuePreset.id;
+    option.dataset.valuePresetId = valuePreset.id;
+    option.textContent = formatValuePresetLabel(valuePreset);
+    select.append(option);
+    if (valuePreset.id === row.valuePresetId) {
+      selectedValuePreset = valuePreset;
+    }
+  });
+
+  if (selectedValuePreset) {
+    select.value = selectedValuePreset.id;
+  } else {
+    select.value = "custom";
+  }
+
+  const slider = createInput({ type: "range", value: row.value, min: 0, max: 255, step: 1 });
+  slider.classList.add("value-slider");
+  slider.dataset.templateId = templateId;
+  slider.dataset.rowId = row.id;
+  slider.dataset.field = "template-value-slider";
+
+  const input = createInput({ type: "number", value: row.value, min: 0, max: 255, step: 1 });
+  input.dataset.templateId = templateId;
+  input.dataset.rowId = row.id;
+  input.dataset.field = "template-value";
+  input.addEventListener("change", (event) => {
+    handleTemplateRowValueChange(templateId, row.id, event);
+    slider.value = event.target.value;
+  });
+
+  slider.addEventListener("input", () => {
+    if (input.disabled) {
+      slider.value = input.value || "0";
+      return;
+    }
+    const numericValue = clamp(Number.parseInt(slider.value, 10) || 0, 0, 255);
+    row.value = numericValue;
+    row.valuePresetId = null;
+    input.value = String(numericValue);
+    syncTemplateInstances(templateId);
+  });
+
+  slider.addEventListener("change", () => {
+    saveLightTemplates();
+  });
+
+  if (selectedValuePreset) {
+    const numericValue = Number.parseInt(selectedValuePreset.value, 10);
+    if (Number.isFinite(numericValue)) {
+      const clamped = clamp(numericValue, 0, 255);
+      input.value = clamped;
+      slider.value = clamped;
+      input.disabled = true;
+      slider.disabled = true;
+    }
+  } else {
+    input.disabled = false;
+    slider.disabled = false;
+  }
+
+  wrapper.append(select, slider, input);
+  return wrapper;
+}
+
+function handleTemplateNameInput(templateId, event) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  template.name = event.target.value;
+  saveLightTemplates();
+  updateLightTemplateCardTitle(event.target.closest(".template-card"), template);
+  const query = templatePickerSearch ? templatePickerSearch.value || "" : "";
+  renderTemplatePickerResults(query);
+}
+
+function addLightTemplate() {
+  const template = createLightTemplateDefaults();
+  lightTemplates.push(template);
+  saveLightTemplates();
+  renderLightTemplates({ focusTemplateId: template.id });
+  setActiveTab("templates");
+}
+
+function duplicateLightTemplate(templateId) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  const clonedRows = (template.rows || []).map((row) =>
+    createTemplateRowDefaults({
+      channel: row.channel,
+      value: row.value,
+      fade: row.fade,
+      channelPresetId: row.channelPresetId,
+      valuePresetId: row.valuePresetId,
+    }),
+  );
+  const duplicateName = template.name ? `${template.name} Copy` : "Untitled Template Copy";
+  const duplicate = createLightTemplateDefaults({ name: duplicateName, rows: clonedRows });
+  lightTemplates.push(duplicate);
+  saveLightTemplates();
+  renderLightTemplates({ focusTemplateId: duplicate.id });
+}
+
+function removeLightTemplate(templateId) {
+  const index = lightTemplates.findIndex((template) => template.id === templateId);
+  if (index === -1) return;
+  lightTemplates.splice(index, 1);
+  saveLightTemplates();
+  renderLightTemplates();
+  removeTemplateInstances(templateId);
+}
+
+function removeTemplateInstances(templateId) {
+  const originalLength = actions.length;
+  actions = actions.filter((action) => action.templateId !== templateId);
+  if (actions.length !== originalLength) {
+    renderActions();
+    queuePreviewSync();
+  }
+}
+
+function addRowToLightTemplate(templateId) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  if (!Array.isArray(template.rows)) {
+    template.rows = [];
+  }
+  const newRow = createTemplateRowDefaults();
+  template.rows.push(newRow);
+  saveLightTemplates();
+  renderLightTemplates({
+    preserveFocus: { templateId, rowId: newRow.id, field: "template-channel" },
+  });
+  syncTemplateInstances(templateId);
+}
+
+function duplicateTemplateRow(templateId, rowId) {
+  const template = getLightTemplate(templateId);
+  if (!template || !Array.isArray(template.rows)) return;
+  const index = template.rows.findIndex((row) => row.id === rowId);
+  if (index === -1) return;
+  const source = template.rows[index];
+  const clone = createTemplateRowDefaults({
+    channel: source.channel,
+    value: source.value,
+    fade: source.fade,
+    channelPresetId: source.channelPresetId,
+    valuePresetId: source.valuePresetId,
+  });
+  template.rows.splice(index + 1, 0, clone);
+  saveLightTemplates();
+  renderLightTemplates({
+    preserveFocus: { templateId, rowId: clone.id, field: "template-channel" },
+  });
+  syncTemplateInstances(templateId);
+}
+
+function removeTemplateRow(templateId, rowId) {
+  const template = getLightTemplate(templateId);
+  if (!template || !Array.isArray(template.rows)) return;
+  const index = template.rows.findIndex((row) => row.id === rowId);
+  if (index === -1) return;
+  template.rows.splice(index, 1);
+  saveLightTemplates();
+  renderLightTemplates({ preserveFocus: { templateId } });
+  syncTemplateInstances(templateId);
+}
+
+function handleTemplateRowChannelPresetChange(templateId, rowId, event) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  const row = getTemplateRow(templateId, rowId);
+  if (!row) return;
+  const selectedId = event.target.value;
+  if (selectedId) {
+    row.channelPresetId = selectedId;
+    const preset = getChannelPreset(selectedId);
+    if (preset) {
+      const channelNumber = Number.parseInt(preset.channel, 10);
+      if (Number.isFinite(channelNumber)) {
+        row.channel = clamp(channelNumber, 1, 512);
+      }
+      if (!Array.isArray(preset.values) || !preset.values.some((value) => value.id === row.valuePresetId)) {
+        row.valuePresetId = null;
+      }
+    }
+  } else {
+    row.channelPresetId = null;
+  }
+  const focusDescriptor = describeFocusedTemplateField(event.target);
+  saveLightTemplates();
+  renderLightTemplates({ preserveFocus: focusDescriptor });
+  syncTemplateInstances(templateId);
+}
+
+function handleTemplateRowChannelInput(templateId, rowId, event) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  const row = getTemplateRow(templateId, rowId);
+  if (!row) return;
+  const raw = Number.parseInt(event.target.value, 10);
+  if (Number.isNaN(raw)) {
+    event.target.classList.add("invalid");
+    event.target.setCustomValidity("Channel must be between 1 and 512.");
+    event.target.reportValidity();
+    return;
+  }
+  const clamped = clamp(raw, 1, 512);
+  event.target.value = clamped;
+  event.target.classList.remove("invalid");
+  event.target.setCustomValidity("");
+  row.channel = clamped;
+  row.channelPresetId = null;
+  saveLightTemplates();
+  syncTemplateInstances(templateId);
+}
+
+function handleTemplateRowValuePresetChange(templateId, rowId, event) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  const row = getTemplateRow(templateId, rowId);
+  if (!row) return;
+  const selectedId = event.target.value;
+  const focusDescriptor = describeFocusedTemplateField(event.target);
+  if (selectedId && selectedId !== "custom" && row.channelPresetId) {
+    const preset = getChannelPreset(row.channelPresetId);
+    const presetValues = preset && Array.isArray(preset.values) ? preset.values : [];
+    const valuePreset = presetValues.find((value) => value.id === selectedId) || null;
+    if (valuePreset) {
+      row.valuePresetId = valuePreset.id;
+      const numericValue = Number.parseInt(valuePreset.value, 10);
+      if (Number.isFinite(numericValue)) {
+        row.value = clamp(numericValue, 0, 255);
+      }
+      saveLightTemplates();
+      renderLightTemplates({ preserveFocus: focusDescriptor });
+      syncTemplateInstances(templateId);
+      return;
+    }
+  }
+  row.valuePresetId = null;
+  saveLightTemplates();
+  renderLightTemplates({ preserveFocus: focusDescriptor });
+  syncTemplateInstances(templateId);
+}
+
+function handleTemplateRowValueChange(templateId, rowId, event) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  const row = getTemplateRow(templateId, rowId);
+  if (!row) return;
+  const raw = Number.parseInt(event.target.value, 10);
+  if (Number.isNaN(raw)) {
+    event.target.classList.add("invalid");
+    event.target.setCustomValidity("Value must be between 0 and 255.");
+    event.target.reportValidity();
+    return;
+  }
+  const clamped = clamp(raw, 0, 255);
+  event.target.value = clamped;
+  event.target.classList.remove("invalid");
+  event.target.setCustomValidity("");
+  row.value = clamped;
+  row.valuePresetId = null;
+  saveLightTemplates();
+  syncTemplateInstances(templateId);
+}
+
+function handleTemplateRowFadeChange(templateId, rowId, event) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  const row = getTemplateRow(templateId, rowId);
+  if (!row) return;
+  const raw = Number.parseFloat(event.target.value);
+  const normalized = Number.isFinite(raw) ? Math.max(0, raw) : 0;
+  row.fade = Number(normalized.toFixed(3));
+  event.target.value = row.fade;
+  saveLightTemplates();
+  syncTemplateInstances(templateId);
+}
+
+function syncTemplateInstances(templateId, options = {}) {
+  if (!templateId) return;
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  const instances = new Map();
+
+  actions.forEach((action, index) => {
+    if (action.templateId !== templateId || !action.templateInstanceId) {
+      return;
+    }
+    const instanceId = action.templateInstanceId;
+    let group = instances.get(instanceId);
+    if (!group) {
+      group = {
+        instanceId,
+        indices: [],
+        stepId: getActionStepId(action),
+        time: action.time || DEFAULT_ACTION.time,
+      };
+      instances.set(instanceId, group);
+    }
+    group.indices.push(index);
+  });
+
+  if (!instances.size) {
+    return;
+  }
+
+  const groups = Array.from(instances.values()).map((group) => {
+    group.indices.sort((a, b) => a - b);
+    group.firstIndex = group.indices.length ? group.indices[0] : actions.length;
+    return group;
+  });
+
+  groups.sort((a, b) => a.firstIndex - b.firstIndex);
+
+  let removedBefore = 0;
+  groups.forEach((group) => {
+    group.removedBefore = removedBefore;
+    removedBefore += group.indices.length;
+  });
+
+  const removalIndices = groups
+    .flatMap((group) => group.indices)
+    .sort((a, b) => b - a);
+
+  removalIndices.forEach((index) => {
+    actions.splice(index, 1);
+  });
+
+  let insertedSoFar = 0;
+  groups.forEach((group) => {
+    const { stepId, time, instanceId, removedBefore: beforeCount = 0 } = group;
+    const timeValue = time || DEFAULT_ACTION.time;
+    const newActions = createActionsFromTemplate(template, stepId, timeValue, instanceId);
+    if (!newActions.length) {
+      return;
+    }
+
+    const baseIndex = group.firstIndex - beforeCount;
+    let insertionIndex = baseIndex + insertedSoFar;
+    if (insertionIndex < 0) insertionIndex = 0;
+    if (insertionIndex > actions.length) insertionIndex = actions.length;
+
+    actions.splice(insertionIndex, 0, ...newActions);
+    insertedSoFar += newActions.length;
+  });
+
+  if (options.render !== false) {
+    renderActions({ preserveFocus: describeFocusedActionField(document.activeElement) });
+    queuePreviewSync();
+  }
+}
+
+function createActionsFromTemplate(template, stepId, time, instanceId) {
+  const rows = Array.isArray(template.rows) ? template.rows : [];
+  const seconds = parseTimeString(time) ?? parseTimeString(DEFAULT_ACTION.time) ?? 0;
+  const timecode = secondsToTimecode(seconds);
+  return rows.map((row) => {
+    const action = {
+      ...DEFAULT_ACTION,
+      time: timecode,
+      channel: clamp(Number.parseInt(row.channel, 10) || 1, 1, 512),
+      value: clamp(Number.parseInt(row.value, 10) || 0, 0, 255),
+      fade: Math.max(0, Number.parseFloat(row.fade) || 0),
+      channelPresetId:
+        typeof row.channelPresetId === "string" && row.channelPresetId ? row.channelPresetId : null,
+      valuePresetId:
+        typeof row.valuePresetId === "string" && row.valuePresetId ? row.valuePresetId : null,
+      templateId: template.id,
+      templateInstanceId: instanceId,
+      templateRowId: row.id,
+    };
+    ensureActionLocalId(action);
+    setActionStepId(action, stepId);
+    return action;
+  });
+}
+
+function generateTemplateInstanceId() {
+  templateInstanceCounter += 1;
+  return `template-instance-${templateInstanceCounter}`;
+}
+
+function applyTemplateToStep(stepId, templateId, options = {}) {
+  const template = getLightTemplate(templateId);
+  if (!template) return;
+  const groupInfo = stepInfoById.get(stepId);
+  const baseTime = options.time || groupInfo?.time || DEFAULT_ACTION.time;
+  let insertionIndex;
+  if (Number.isInteger(options.insertIndex)) {
+    insertionIndex = options.insertIndex;
+  } else if (groupInfo && Array.isArray(groupInfo.indices) && groupInfo.indices.length) {
+    insertionIndex = groupInfo.indices[groupInfo.indices.length - 1] + 1;
+  } else {
+    insertionIndex = actions.length;
+  }
+  if (!Number.isInteger(insertionIndex)) {
+    insertionIndex = actions.length;
+  }
+
+  const instanceId = generateTemplateInstanceId();
+  const newActions = createActionsFromTemplate(template, stepId, baseTime, instanceId);
+  if (!newActions.length) {
+    showStatus("Selected template has no rows to add.", "info");
+    return;
+  }
+  let targetIndex = insertionIndex;
+  if (targetIndex < 0) targetIndex = 0;
+  if (targetIndex > actions.length) targetIndex = actions.length;
+
+  newActions.forEach((action, index) => {
+    actions.splice(targetIndex + index, 0, action);
+  });
+
+  renderActions();
+  queuePreviewSync();
+}
+
+function openTemplatePicker(stepId) {
+  if (!templatePickerEl) return;
+  templatePickerStepId = stepId;
+  templatePickerEl.hidden = false;
+  templatePickerEl.setAttribute("aria-hidden", "false");
+  templatePickerEl.classList.add("is-visible");
+  const query = templatePickerSearch ? templatePickerSearch.value || "" : "";
+  renderTemplatePickerResults(query);
+  focusTemplatePickerSearch();
+}
+
+function closeTemplatePicker() {
+  if (!templatePickerEl) return;
+  templatePickerEl.hidden = true;
+  templatePickerEl.setAttribute("aria-hidden", "true");
+  templatePickerEl.classList.remove("is-visible");
+  templatePickerStepId = null;
+  if (templatePickerSearch) {
+    templatePickerSearch.value = "";
+  }
+}
+
+function isTemplatePickerOpen() {
+  return Boolean(templatePickerEl && !templatePickerEl.hidden);
+}
+
+function focusTemplatePickerSearch() {
+  if (!templatePickerSearch) return;
+  try {
+    templatePickerSearch.focus({ preventScroll: true });
+  } catch (error) {
+    templatePickerSearch.focus();
+  }
+  templatePickerSearch.select();
+}
+
+function renderTemplatePickerResults(query) {
+  if (!templatePickerResults) return;
+  templatePickerResults.innerHTML = "";
+  const normalized = (query || "").trim().toLowerCase();
+  const items = normalized
+    ? lightTemplates.filter((template) =>
+        (template.name || "").toLowerCase().includes(normalized),
+      )
+    : [...lightTemplates];
+
+  if (!items.length) {
+    const emptyItem = document.createElement("li");
+    emptyItem.className = "template-picker__empty";
+    emptyItem.textContent = "No templates match your search.";
+    templatePickerResults.append(emptyItem);
+    return;
+  }
+
+  items.forEach((template) => {
+    const item = document.createElement("li");
+    item.className = "template-picker__item";
+    const button = document.createElement("button");
+    button.type = "button";
+    button.className = "template-picker__option";
+    button.textContent = formatLightTemplateTitle(template);
+    button.dataset.templateId = template.id;
+    button.addEventListener("click", () => handleTemplatePickerSelection(template.id));
+    item.append(button);
+    templatePickerResults.append(item);
+  });
+}
+
+function handleTemplatePickerSelection(templateId) {
+  if (!templatePickerStepId) {
+    closeTemplatePicker();
+    return;
+  }
+  applyTemplateToStep(templatePickerStepId, templateId);
+  closeTemplatePicker();
+}
+
 function getChannelPreset(presetId) {
   return channelPresets.find((preset) => preset.id === presetId) || null;
 }
@@ -2015,12 +3704,28 @@ function prepareActionsForSave() {
     if (fade < 0) {
       throw new Error(`Row ${index + 1}: fade cannot be negative.`);
     }
-    prepared.push({
+    const entry = {
       time: secondsToTimecode(seconds),
       channel,
       value,
       fade: Number(fade.toFixed(3)),
-    });
+    };
+    if (action.channelPresetId) {
+      entry.channelPresetId = action.channelPresetId;
+    }
+    if (action.valuePresetId) {
+      entry.valuePresetId = action.valuePresetId;
+    }
+    if (action.templateId) {
+      entry.templateId = action.templateId;
+    }
+    if (action.templateInstanceId) {
+      entry.templateInstanceId = action.templateInstanceId;
+    }
+    if (action.templateRowId) {
+      entry.templateRowId = action.templateRowId;
+    }
+    prepared.push(entry);
   });
   return sortActions(prepared);
 }

--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -12,34 +12,115 @@
         <h1>DMX Template Builder</h1>
         <p>Create and edit lighting cues that sync with your show videos.</p>
       </div>
-      <div class="builder-header__actions">
-        <button
-          id="open-channel-presets"
-          type="button"
-          class="secondary toggle-button"
-          aria-pressed="true"
-        >
-          Channel Presets
-        </button>
-      </div>
     </header>
 
-    <section class="builder-controls">
-      <label class="control-group" for="video-select">
-        <span class="control-label">Song</span>
-        <select id="video-select">
-          <option value="">Select a song…</option>
-        </select>
-      </label>
-      <button id="add-row" type="button" class="control-button" disabled>Add Step</button>
-      <button id="save-template" type="button" class="primary" disabled>Save Template</button>
-      <button id="export-template" type="button" class="secondary" disabled>Export JSON</button>
-      <span id="status-message" role="status" aria-live="polite"></span>
+    <nav class="builder-tabs" role="tablist">
+      <button
+        type="button"
+        class="builder-tab is-active"
+        role="tab"
+        aria-selected="true"
+        data-tab="timeline"
+      >
+        Timeline
+      </button>
+      <button
+        type="button"
+        class="builder-tab"
+        role="tab"
+        aria-selected="false"
+        data-tab="presets"
+      >
+        Channel Presets
+      </button>
+      <button
+        type="button"
+        class="builder-tab"
+        role="tab"
+        aria-selected="false"
+        data-tab="templates"
+      >
+        Light Templates
+      </button>
+    </nav>
+
+    <section id="timeline-panel" class="tab-panel" data-tab-panel="timeline">
+      <section class="builder-controls">
+        <label class="control-group" for="video-select">
+          <span class="control-label">Song</span>
+          <select id="video-select">
+            <option value="">Select a song…</option>
+          </select>
+        </label>
+        <button id="add-step" type="button" class="control-button" disabled>
+          Add Step
+        </button>
+        <button id="save-template" type="button" class="primary" disabled>
+          Save Template
+        </button>
+        <button id="export-template" type="button" class="secondary" disabled>
+          Export JSON
+        </button>
+        <span id="status-message" role="status" aria-live="polite"></span>
+      </section>
+
+      <section class="template-info" id="template-info" hidden></section>
+
+      <div id="timeline-empty-state" class="timeline-empty" hidden>
+        <p>Select a song to start building a timeline.</p>
+      </div>
+
+      <main class="builder-layout" hidden aria-hidden="true">
+        <section class="preview-panel">
+          <h2>Video Preview</h2>
+          <video id="preview-video" controls preload="metadata"></video>
+          <section
+            id="channel-status"
+            class="channel-status"
+            aria-live="polite"
+            aria-label="Active channels"
+          >
+            <h3 class="channel-status__title">Active Channels</h3>
+            <div id="channel-status-list" class="channel-status__content">
+              <p class="channel-status__empty">All channels at blackout.</p>
+            </div>
+          </section>
+          <div class="video-hints">
+            <p>
+              Select a row in the table to jump to that cue. The time input keeps the
+              video preview aligned with the cue you are editing.
+            </p>
+          </div>
+        </section>
+
+        <section class="table-panel">
+          <h2>Lighting Steps</h2>
+          <div class="table-wrapper">
+            <table class="actions-table">
+              <thead>
+                <tr>
+                  <th scope="col">Time (HH:MM:SS)</th>
+                  <th scope="col">Channel</th>
+                  <th scope="col">Value</th>
+                  <th scope="col">Fade (s)</th>
+                  <th scope="col">Tools</th>
+                </tr>
+              </thead>
+              <tbody id="actions-body"></tbody>
+            </table>
+          </div>
+        </section>
+      </main>
     </section>
 
-    <section class="template-info" id="template-info" hidden></section>
-
-    <section class="preset-settings" aria-labelledby="channel-presets-heading">
+    <section
+      id="presets-panel"
+      class="preset-settings tab-panel"
+      data-tab-panel="presets"
+      aria-labelledby="channel-presets-heading"
+      hidden
+      aria-hidden="true"
+    >
       <header class="preset-settings__header">
         <div>
           <h2 id="channel-presets-heading">Channel Presets</h2>
@@ -58,47 +139,30 @@
       <div id="channel-presets" class="preset-settings__list" aria-live="polite"></div>
     </section>
 
-    <main class="builder-layout">
-      <section class="preview-panel">
-        <h2>Video Preview</h2>
-        <video id="preview-video" controls preload="metadata"></video>
-        <section
-          id="channel-status"
-          class="channel-status"
-          aria-live="polite"
-          aria-label="Active channels"
-        >
-          <h3 class="channel-status__title">Active Channels</h3>
-          <div id="channel-status-list" class="channel-status__content">
-            <p class="channel-status__empty">All channels at blackout.</p>
-          </div>
-        </section>
-        <div class="video-hints">
+    <section
+      id="templates-panel"
+      class="template-library tab-panel"
+      data-tab-panel="templates"
+      hidden
+      aria-hidden="true"
+    >
+      <header class="template-library__header">
+        <div>
+          <h2>Light Templates</h2>
           <p>
-            Select a row in the table to jump to that cue. The time input keeps the
-            video preview aligned with the cue you are editing.
+            Assemble reusable channel combinations that you can drop into any
+            step. Templates don’t include a timestamp so they work anywhere in
+            your timeline.
           </p>
         </div>
-      </section>
-
-      <section class="table-panel">
-        <h2>Lighting Steps</h2>
-        <div class="table-wrapper">
-          <table class="actions-table">
-            <thead>
-              <tr>
-                <th scope="col">Time (HH:MM:SS)</th>
-                <th scope="col">Channel</th>
-                <th scope="col">Value</th>
-                <th scope="col">Fade (s)</th>
-                <th scope="col">Tools</th>
-              </tr>
-            </thead>
-            <tbody id="actions-body"></tbody>
-          </table>
+        <div class="template-library__actions">
+          <button id="add-light-template" type="button" class="primary">
+            New Template
+          </button>
         </div>
-      </section>
-    </main>
+      </header>
+      <div id="light-templates" class="template-library__list" aria-live="polite"></div>
+    </section>
 
     <template id="action-row-template">
       <tr>
@@ -110,6 +174,41 @@
       </tr>
     </template>
 
+    <div id="template-picker" class="template-picker" hidden aria-hidden="true">
+      <div class="template-picker__backdrop" data-template-picker-close></div>
+      <div class="template-picker__dialog" role="dialog" aria-modal="true" aria-labelledby="template-picker-title">
+        <header class="template-picker__header">
+          <h2 id="template-picker-title">Add Template to Step</h2>
+          <button type="button" class="template-picker__close" data-template-picker-close>
+            <span aria-hidden="true">×</span>
+            <span class="visually-hidden">Close</span>
+          </button>
+        </header>
+        <div class="template-picker__body">
+          <label class="template-picker__search">
+            <span class="visually-hidden">Search templates</span>
+            <input
+              type="search"
+              id="template-picker-search"
+              placeholder="Search templates…"
+              autocomplete="off"
+            />
+          </label>
+          <ul id="template-picker-results" class="template-picker__results" role="listbox" aria-live="polite"></ul>
+        </div>
+      </div>
+    </div>
+
+    <template id="template-row-template">
+      <tr>
+        <td data-template-column="name"></td>
+        <td data-template-column="channel"></td>
+        <td data-template-column="value"></td>
+        <td data-template-column="fade"></td>
+        <td data-template-column="tools"></td>
+      </tr>
+    </template>
+  
     <script src="builder.js" type="module"></script>
   </body>
 </html>

--- a/dmx.py
+++ b/dmx.py
@@ -775,14 +775,26 @@ class DMXShowManager:
         normalized: List[Dict[str, object]] = []
         for raw in actions:
             action = DMXAction.from_dict(raw)
-            normalized.append(
-                {
-                    "time": self.format_timecode(action.time_seconds),
-                    "channel": action.channel,
-                    "value": action.value,
-                    "fade": round(action.fade, 3),
-                }
-            )
+            entry: Dict[str, object] = {
+                "time": self.format_timecode(action.time_seconds),
+                "channel": action.channel,
+                "value": action.value,
+                "fade": round(action.fade, 3),
+            }
+
+            if isinstance(raw, dict):
+                for key in (
+                    "channelPresetId",
+                    "valuePresetId",
+                    "templateId",
+                    "templateInstanceId",
+                    "templateRowId",
+                ):
+                    value = raw.get(key)
+                    if isinstance(value, str) and value:
+                        entry[key] = value
+
+            normalized.append(entry)
 
         payload = {"actions": sorted(normalized, key=lambda item: parse_timecode(str(item["time"])))}
         template_path.parent.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary
- add JSON-backed storage and REST endpoints for light templates and persist template metadata alongside DMX actions
- introduce tabbed builder UI with a dedicated light template editor, picker overlay, duplication controls, and template banners inside steps
- fix template instance synchronization so editing a template reliably rebuilds its timeline cues in-place

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e117c56cd4833282e31dd251916ab5