### PR TITLE
Refactor DMX builder timeline grid and sync paused previews

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -866,51 +866,92 @@ body {
   overflow: auto;
 }
 
-.actions-table {
-  width: 100%;
-  border-collapse: collapse;
+.actions-grid {
+  --actions-grid-template: 2.5rem minmax(10rem, 1.1fr) minmax(8rem, 1fr) minmax(7rem, 0.8fr) minmax(9rem, 1fr);
+  border: 1px solid rgba(148, 163, 184, 0.25);
+  border-radius: 0.6rem;
+  overflow: hidden;
+  background: rgba(30, 41, 59, 0.5);
   font-size: 0.95rem;
+  min-width: 100%;
 }
 
-.actions-table thead {
+.actions-grid__header,
+.actions-grid__row {
+  display: grid;
+  grid-template-columns: var(--actions-grid-template);
+  align-items: stretch;
+}
+
+.actions-grid__header {
   background: rgba(129, 140, 248, 0.18);
+  font-weight: 600;
 }
 
-.actions-table th,
-.actions-table td {
+.actions-grid__body {
+  display: flex;
+  flex-direction: column;
+}
+
+.actions-grid__cell {
   padding: 0.5rem 0.6rem;
-  text-align: left;
   border-bottom: 1px solid rgba(148, 163, 184, 0.25);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
 }
 
-.actions-table__drag-header {
-  width: 2.25rem;
+.actions-grid__cell > input,
+.actions-grid__cell > select,
+.actions-grid__cell > .preset-select {
+  flex: 1;
+}
+
+.actions-grid__header-cell {
+  align-items: center;
+  justify-content: flex-start;
+}
+
+.actions-grid__cell--handle {
+  width: 2.5rem;
   padding-left: 0.25rem;
   padding-right: 0.25rem;
+  justify-content: center;
 }
 
-.actions-table td[data-column="handle"] {
-  width: 2.25rem;
-  padding: 0.25rem 0.25rem;
+.actions-grid__cell--fade,
+.actions-grid__cell--tools {
+  justify-content: flex-start;
 }
 
-.actions-table tbody tr.is-active {
+.actions-grid__cell--template {
+  align-items: stretch;
+}
+
+.actions-grid__body > .actions-grid__row:last-child .actions-grid__cell {
+  border-bottom: none;
+}
+
+.action-group-item.is-active {
   background: rgba(129, 140, 248, 0.12);
 }
 
-.actions-table tbody tr.is-active td {
+.action-group-item.is-active .actions-grid__cell {
   border-bottom-color: rgba(129, 140, 248, 0.4);
 }
 
-.action-group-header td {
+.action-group-header {
   background: rgba(148, 163, 184, 0.14);
-  font-weight: 600;
-  padding-top: 0.6rem;
-  padding-bottom: 0.6rem;
-  border-bottom-color: rgba(148, 163, 184, 0.35);
 }
 
-.action-group-header.is-active td {
+.action-group-header .actions-grid__cell {
+  grid-column: 1 / -1;
+  border-bottom-color: rgba(148, 163, 184, 0.35);
+  padding-top: 0.6rem;
+  padding-bottom: 0.6rem;
+}
+
+.action-group-header.is-active .actions-grid__cell {
   border-bottom-color: rgba(129, 140, 248, 0.4);
   background: rgba(129, 140, 248, 0.18);
 }
@@ -1001,7 +1042,7 @@ body {
   box-shadow: 0 0 0 1px rgba(248, 113, 113, 0.5);
 }
 
-.action-group-header.is-drop-target td {
+.action-group-header.is-drop-target {
   outline: 2px dashed rgba(129, 140, 248, 0.6);
   outline-offset: -4px;
 }
@@ -1010,15 +1051,15 @@ body {
   opacity: 0.6;
 }
 
-.action-group-item.drop-before td {
+.action-group-item.drop-before {
   box-shadow: inset 0 2px 0 0 var(--accent);
 }
 
-.action-group-item.drop-after td {
+.action-group-item.drop-after {
   box-shadow: inset 0 -2px 0 0 var(--accent);
 }
 
-.action-group-item td:first-child {
+.action-group-item [data-column="handle"] {
   padding-left: 0.25rem;
   padding-right: 0.25rem;
 }
@@ -1056,8 +1097,8 @@ body {
   pointer-events: none;
 }
 
-.actions-table td input,
-.actions-table td select {
+.actions-grid__cell input,
+.actions-grid__cell select {
   width: 100%;
   padding: 0.35rem 0.4rem;
   border-radius: 0.4rem;
@@ -1067,13 +1108,13 @@ body {
   font-size: 0.95rem;
 }
 
-.actions-table td input:focus,
-.actions-table td select:focus {
+.actions-grid__cell input:focus,
+.actions-grid__cell select:focus {
   outline: 2px solid rgba(129, 140, 248, 0.6);
   border-color: rgba(129, 140, 248, 0.9);
 }
 
-.actions-table td input.invalid {
+.actions-grid__cell input.invalid {
   border-color: #f87171;
   outline-color: #f87171;
 }
@@ -1118,6 +1159,12 @@ body {
 
 .action-group-template {
   background: rgba(59, 130, 246, 0.08);
+}
+
+.action-group-template [data-column="content"] {
+  grid-column: 2 / -1;
+  padding-left: 0.6rem;
+  padding-right: 0.6rem;
 }
 
 .action-group-template__content {
@@ -1180,6 +1227,12 @@ body {
   text-align: center;
   opacity: 0.75;
   font-size: 0.95rem;
+}
+
+.actions-grid__empty {
+  padding: 1.5rem;
+  text-align: center;
+  opacity: 0.7;
 }
 
 .row-tools button {

--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -87,7 +87,7 @@
           </section>
           <div class="video-hints">
             <p>
-              Select a row in the table to jump to that cue. The time input keeps the
+              Select a row in the timeline to jump to that cue. The time input keeps the
               video preview aligned with the cue you are editing.
             </p>
           </div>
@@ -96,20 +96,29 @@
         <section class="table-panel">
           <h2>Lighting Steps</h2>
           <div class="table-wrapper">
-            <table class="actions-table">
-              <thead>
-                <tr>
-                  <th scope="col" class="actions-table__drag-header">
-                    <span class="visually-hidden">Reorder</span>
-                  </th>
-                  <th scope="col">Channel</th>
-                  <th scope="col">Value</th>
-                  <th scope="col">Fade (s)</th>
-                  <th scope="col">Tools</th>
-                </tr>
-              </thead>
-              <tbody id="actions-body"></tbody>
-            </table>
+            <div class="actions-grid" role="grid" aria-label="Lighting steps timeline">
+              <div class="actions-grid__header" role="row">
+                <span
+                  class="actions-grid__cell actions-grid__cell--handle actions-grid__header-cell"
+                  role="columnheader"
+                >
+                  <span class="visually-hidden">Reorder</span>
+                </span>
+                <span class="actions-grid__cell actions-grid__header-cell" role="columnheader">
+                  Channel
+                </span>
+                <span class="actions-grid__cell actions-grid__header-cell" role="columnheader">
+                  Value
+                </span>
+                <span class="actions-grid__cell actions-grid__header-cell" role="columnheader">
+                  Fade (s)
+                </span>
+                <span class="actions-grid__cell actions-grid__header-cell" role="columnheader">
+                  Tools
+                </span>
+              </div>
+              <div id="actions-body" class="actions-grid__body" role="rowgroup"></div>
+            </div>
           </div>
         </section>
       </main>
@@ -173,13 +182,13 @@
     </section>
 
     <template id="action-row-template">
-      <tr>
-        <td data-column="handle"></td>
-        <td data-column="channel"></td>
-        <td data-column="value"></td>
-        <td data-column="fade"></td>
-        <td data-column="tools"></td>
-      </tr>
+      <div class="actions-grid__row action-group-item" role="row">
+        <div class="actions-grid__cell actions-grid__cell--handle" data-column="handle"></div>
+        <div class="actions-grid__cell" data-column="channel"></div>
+        <div class="actions-grid__cell" data-column="value"></div>
+        <div class="actions-grid__cell actions-grid__cell--fade" data-column="fade"></div>
+        <div class="actions-grid__cell actions-grid__cell--tools" data-column="tools"></div>
+      </div>
     </template>
 
     <div id="template-picker" class="template-picker" hidden aria-hidden="true">

--- a/app.py
+++ b/app.py
@@ -953,9 +953,11 @@ def api_dmx_preview() -> Any:
         return jsonify({"error": "Missing 'actions' list in request body"}), 400
 
     start_time = data.get("start_time", 0.0)
+    paused_raw = data.get("paused", False)
+    paused = bool(paused_raw) if isinstance(paused_raw, bool) else False
 
     try:
-        dmx_manager.start_preview(actions_payload, start_time=start_time)
+        dmx_manager.start_preview(actions_payload, start_time=start_time, paused=paused)
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
     except Exception:  # pragma: no cover - defensive logging


### PR DESCRIPTION
## Summary
- replace the timeline table with a div-based grid layout and update styling in the DMX builder
- ensure preview updates honour the video pause state instead of forcing playback or running the light sequence
- extend the preview API/manager to accept a paused flag and cover the behaviour with unit tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e28df47b7c8332b795ba5040dec3f5