### PR TITLE
Add template builder system controls and fix custom DMX value handling

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -100,6 +100,17 @@ body {
   border-bottom: 1px solid rgba(255, 255, 255, 0.08);
 }
 
+.system-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  margin-left: auto;
+}
+
+.system-actions button {
+  white-space: nowrap;
+}
+
 .control-group {
   display: flex;
   flex-direction: column;

--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -61,6 +61,17 @@
         <button id="export-template" type="button" class="secondary" disabled>
           Export JSON
         </button>
+        <div class="system-actions">
+          <button id="system-update" type="button" class="secondary">
+            Update &amp; Restart
+          </button>
+          <button id="system-restart" type="button" class="secondary">
+            Restart Pi
+          </button>
+          <button id="system-shutdown" type="button" class="secondary">
+            Shutdown Pi
+          </button>
+        </div>
         <span id="status-message" role="status" aria-live="polite"></span>
       </section>
 

--- a/dmx.py
+++ b/dmx.py
@@ -39,8 +39,7 @@ DEFAULT_CHANNELS = 512
 DMX_FPS = 30.0
 DMX_BREAK_DURATION = float(os.environ.get("DMX_BREAK_DURATION", "0.00012"))
 DMX_MARK_AFTER_BREAK = float(os.environ.get("DMX_MARK_AFTER_BREAK", "0.000012"))
-#DEFAULT_STARTUP_LEVELS = "1=255,2=255,3=255"
-DEFAULT_STARTUP_LEVELS = ""
+DEFAULT_STARTUP_LEVELS = "1=255,2=255,3=255"
 
 def _clamp(value: int, low: int, high: int) -> int:
     return max(low, min(high, value))


### PR DESCRIPTION
## Summary
- add update/restart/shutdown controls to the DMX Template Builder UI and wire them to new API endpoints
- ensure manual DMX value edits take effect immediately and respect template delays when building actions
- expose backend system management helpers and restore default DMX startup levels

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e3e556bb1483328ad8455655c9a1a1