### PR TITLE
Fix duplicate options identifier in DMX template builder

### DIFF
--- a/DMX Template Builder/builder.js
+++ b/DMX Template Builder/builder.js
@@ -1238,8 +1238,8 @@ function createTemplateLoopControls(instanceId, groupId, loop, options = {}) {
 
   toggleLabel.append(toggleInput, toggleText);
 
-  const options = document.createElement("div");
-  options.className = "template-loop__options";
+  const optionsContainer = document.createElement("div");
+  optionsContainer.className = "template-loop__options";
 
   const countLabel = document.createElement("label");
   countLabel.className = "template-loop__count-label";
@@ -1296,9 +1296,9 @@ function createTemplateLoopControls(instanceId, groupId, loop, options = {}) {
 
   modeLabel.append(modeText, modeSelect);
 
-  options.append(countLabel, infiniteLabel, modeLabel);
+  optionsContainer.append(countLabel, infiniteLabel, modeLabel);
 
-  container.append(toggleLabel, options);
+  container.append(toggleLabel, optionsContainer);
   updateTemplateLoopControlsState(container, normalized);
   return container;
 }


### PR DESCRIPTION
## Summary
- rename the template loop options container element to avoid redeclaring the existing options parameter
- ensure the loop controls append to the renamed container

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e451124c508332a93838e83787c448