### PR TITLE
Fix template redeclaration causing builder runtime error

### DIFF
--- a/DMX Template Builder/builder.js
+++ b/DMX Template Builder/builder.js
@@ -1503,7 +1503,6 @@ function createTemplateInstanceRow(group, action, index, count) {
   loopSummary.className = "action-group-template__loop-summary";
   loopSummary.dataset.role = "template-loop-summary";
   const loop = normalizeTemplateLoop(action.templateLoop);
-  const template = action.templateId ? getLightTemplate(action.templateId) : null;
   const timeline = template ? buildTemplateTimeline(template) : null;
   const totalDuration = timeline ? Number(timeline.totalDuration || 0) : 0;
   if (totalDuration > 0) {


### PR DESCRIPTION
## Summary
- reuse the existing template reference when building the loop summary
- prevent redeclaration that triggered a runtime SyntaxError in builder.js

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e4524b69208332973c27622ff08fc1