### PR TITLE
Ensure shows start from zero and improve template previews

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -270,6 +270,24 @@ body {
   padding: 1rem;
 }
 
+.template-library__filter {
+  margin-bottom: 0.75rem;
+}
+
+.template-library__filter input {
+  width: 100%;
+  padding: 0.55rem 0.75rem;
+  border-radius: 0.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(30, 41, 59, 0.75);
+  color: inherit;
+}
+
+.template-library__filter input:focus-visible {
+  outline: 2px solid rgba(99, 102, 241, 0.7);
+  outline-offset: 2px;
+}
+
 .template-list {
   list-style: none;
   margin: 0;
@@ -860,6 +878,7 @@ body {
   gap: 1.5rem;
   padding: 1.5rem clamp(1rem, 3vw, 2.5rem) 2.5rem;
   flex: 1;
+  align-items: start;
 }
 
 .preview-panel,
@@ -872,6 +891,12 @@ body {
   flex-direction: column;
   gap: 1rem;
   box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.6);
+}
+
+.preview-panel {
+  position: sticky;
+  top: 1.5rem;
+  align-self: start;
 }
 
 .preview-panel h2,

--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -188,6 +188,16 @@
       <div class="template-library__split">
         <aside class="template-library__sidebar" aria-live="polite">
           <h3 class="visually-hidden">Template list</h3>
+          <div class="template-library__filter">
+            <label class="visually-hidden" for="light-template-filter">Filter templates</label>
+            <input
+              type="search"
+              id="light-template-filter"
+              placeholder="Filter templates…"
+              autocomplete="off"
+              spellcheck="false"
+            />
+          </div>
           <ul id="light-templates" class="template-list" role="list"></ul>
         </aside>
         <section id="template-detail" class="template-detail" aria-live="polite"></section>

--- a/app.py
+++ b/app.py
@@ -1109,8 +1109,15 @@ def api_dmx_preview() -> Any:
     paused_raw = data.get("paused", False)
     paused = bool(paused_raw) if isinstance(paused_raw, bool) else False
 
+    template_preview = bool(data.get("template_preview"))
+
     try:
-        dmx_manager.start_preview(actions_payload, start_time=start_time, paused=paused)
+        dmx_manager.start_preview(
+            actions_payload,
+            start_time=start_time,
+            paused=paused,
+            template_preview=template_preview,
+        )
     except ValueError as exc:
         return jsonify({"error": str(exc)}), 400
     except Exception:  # pragma: no cover - defensive logging

--- a/tests/test_dmx_output.py
+++ b/tests/test_dmx_output.py
@@ -1,0 +1,39 @@
+import sys
+import time
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from dmx import DMXOutput
+
+
+def _wait_for_transitions(duration: float) -> None:
+    # Give transition threads time to process without relying on busy waiting.
+    time.sleep(duration)
+
+
+def test_transition_cancels_previous_fade_on_same_channel() -> None:
+    output = DMXOutput()
+    try:
+        output.set_channel(1, 0)
+        output.transition_channel(1, 255, 0.6)
+        _wait_for_transitions(0.05)
+        output.transition_channel(1, 100, 0.2)
+        _wait_for_transitions(0.8)
+        final_value = output.get_channel(1)
+        assert 95 <= final_value <= 105
+    finally:
+        output.shutdown()
+
+
+def test_set_channel_cancels_active_transition() -> None:
+    output = DMXOutput()
+    try:
+        output.set_channel(1, 0)
+        output.transition_channel(1, 255, 0.6)
+        _wait_for_transitions(0.05)
+        output.set_channel(1, 10)
+        _wait_for_transitions(0.7)
+        assert output.get_channel(1) <= 12
+    finally:
+        output.shutdown()


### PR DESCRIPTION
## Summary
- reset DMX show start levels to zero while honoring immediate timeline cues
- flag template preview requests so previews use a blank baseline
- loop template preview actions when delays are present for easier visual editing

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e48d8bc1948332b6706034678fc6b4