### PR TITLE
Refine channel preset workflow in builder

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -1261,6 +1261,10 @@ body {
   align-items: center;
 }
 
+.preset-select--channel {
+  grid-template-columns: minmax(140px, 1fr);
+}
+
 .preset-select select {
   width: auto;
   min-width: max-content;


### PR DESCRIPTION
## Summary
- remove the "Custom" entry and numeric channel input so the channel dropdown now only exposes presets
- automatically apply the selected or first available preset to actions and template rows, updating values when presets change
- drop the timeline "Go to this cue" tool button and adjust styling for the slimmer channel selector

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68e53b9a471c8332bb447fb609f9f712