### PR TITLE
Add channel preset grouping and timeline filtering

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -967,6 +967,225 @@ input::-webkit-inner-spin-button {
   font-size: 1.2rem;
 }
 
+.table-panel__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  flex-wrap: wrap;
+}
+
+.table-panel__header h2 {
+  margin: 0;
+}
+
+.channel-filter {
+  position: relative;
+  margin-left: auto;
+  display: inline-flex;
+  align-items: stretch;
+}
+
+.channel-filter__button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.4rem 0.85rem;
+  border-radius: 999px;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(30, 41, 59, 0.6);
+  color: inherit;
+  cursor: pointer;
+  font-size: 0.9rem;
+  font-weight: 600;
+  letter-spacing: 0.01em;
+  transition: border-color 0.2s ease, background-color 0.2s ease, box-shadow 0.2s ease;
+}
+
+.channel-filter__button:hover,
+.channel-filter__button:focus-visible {
+  border-color: rgba(129, 140, 248, 0.8);
+  background: rgba(129, 140, 248, 0.18);
+}
+
+.channel-filter__button:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.5);
+  outline-offset: 2px;
+}
+
+.channel-filter__button.is-active,
+.channel-filter.is-active .channel-filter__button {
+  border-color: rgba(129, 140, 248, 0.75);
+  background: rgba(129, 140, 248, 0.2);
+}
+
+.channel-filter.is-open .channel-filter__button {
+  box-shadow: 0 12px 30px rgba(15, 23, 42, 0.55);
+}
+
+.channel-filter__button-label {
+  white-space: nowrap;
+}
+
+.channel-filter__button-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.5rem;
+  padding: 0 0.45rem;
+  border-radius: 999px;
+  background: rgba(129, 140, 248, 0.25);
+  font-size: 0.78rem;
+  font-weight: 600;
+}
+
+.channel-filter__button-count[hidden] {
+  display: none;
+}
+
+.channel-filter__chevron {
+  font-size: 0.75rem;
+  opacity: 0.85;
+  transition: transform 0.2s ease;
+}
+
+.channel-filter.is-open .channel-filter__chevron {
+  transform: rotate(-180deg);
+}
+
+.channel-filter__dropdown {
+  position: absolute;
+  right: 0;
+  top: calc(100% + 0.5rem);
+  min-width: 18rem;
+  padding: 0.9rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 25px 50px -12px rgba(15, 23, 42, 0.75);
+  backdrop-filter: blur(6px);
+  z-index: 40;
+}
+
+.channel-filter__dropdown[hidden] {
+  display: none;
+}
+
+.channel-filter__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.75rem;
+  margin-bottom: 0.75rem;
+}
+
+.channel-filter__title {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  opacity: 0.7;
+}
+
+.channel-filter__clear {
+  border: none;
+  background: none;
+  color: rgba(129, 140, 248, 0.95);
+  font-size: 0.85rem;
+  font-weight: 600;
+  cursor: pointer;
+  padding: 0.1rem 0.25rem;
+  transition: opacity 0.2s ease;
+}
+
+.channel-filter__clear:hover:not(:disabled) {
+  opacity: 0.8;
+}
+
+.channel-filter__clear:disabled {
+  opacity: 0.45;
+  cursor: default;
+}
+
+.channel-filter__groups {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  max-height: 18rem;
+  overflow-y: auto;
+  padding-right: 0.25rem;
+}
+
+.channel-filter__groups::-webkit-scrollbar {
+  width: 0.35rem;
+}
+
+.channel-filter__groups::-webkit-scrollbar-thumb {
+  background: rgba(129, 140, 248, 0.45);
+  border-radius: 999px;
+}
+
+.channel-filter__group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.45rem;
+  padding-bottom: 0.4rem;
+  border-bottom: 1px solid rgba(148, 163, 184, 0.15);
+}
+
+.channel-filter__group:last-child {
+  border-bottom: none;
+  padding-bottom: 0;
+}
+
+.channel-filter__group-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-weight: 600;
+  font-size: 0.85rem;
+}
+
+.channel-filter__group-name {
+  flex: 1;
+}
+
+.channel-filter__options {
+  list-style: none;
+  margin: 0;
+  padding: 0 0 0 1.6rem;
+  display: grid;
+  gap: 0.4rem;
+}
+
+.channel-filter__option {
+  margin: 0;
+  padding: 0;
+}
+
+.channel-filter__option-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.45rem;
+  font-size: 0.85rem;
+}
+
+.channel-filter__option-name {
+  opacity: 0.85;
+}
+
+.channel-filter__checkbox {
+  width: 1rem;
+  height: 1rem;
+  accent-color: #818cf8;
+}
+
+.channel-filter__empty {
+  font-size: 0.85rem;
+  text-align: center;
+  opacity: 0.7;
+}
+
 #preview-video {
   width: 100%;
   border-radius: 0.5rem;
@@ -1528,6 +1747,18 @@ input::-webkit-inner-spin-button {
   padding: 1.5rem;
   text-align: center;
   opacity: 0.7;
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.channel-filter__no-results span {
+  font-weight: 600;
+}
+
+.channel-filter__empty-button {
+  font-size: 0.85rem;
+  padding: 0.35rem 0.9rem;
 }
 
 .row-tools button:not(.icon-button) {
@@ -1547,6 +1778,19 @@ input::-webkit-inner-spin-button {
   padding: 1.5rem;
   text-align: center;
   opacity: 0.7;
+}
+
+@media (max-width: 720px) {
+  .channel-filter {
+    width: 100%;
+    justify-content: flex-start;
+  }
+
+  .channel-filter__dropdown {
+    left: 0;
+    right: auto;
+    width: min(22rem, 100%);
+  }
 }
 
 @media (max-width: 960px) {

--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -105,7 +105,44 @@
         </section>
 
         <section class="table-panel">
-          <h2>Lighting Steps</h2>
+          <header class="table-panel__header">
+            <h2>Lighting Steps</h2>
+            <div class="channel-filter" id="channel-filter">
+              <button
+                type="button"
+                id="channel-filter-button"
+                class="channel-filter__button"
+                aria-haspopup="true"
+                aria-expanded="false"
+                aria-controls="channel-filter-dropdown"
+              >
+                <span class="channel-filter__button-label">Filter Channels</span>
+                <span id="channel-filter-count" class="channel-filter__button-count" hidden></span>
+                <span class="channel-filter__chevron" aria-hidden="true">▾</span>
+              </button>
+              <div
+                id="channel-filter-dropdown"
+                class="channel-filter__dropdown"
+                role="menu"
+                aria-label="Filter timeline by channel preset"
+                hidden
+                aria-hidden="true"
+              >
+                <div class="channel-filter__header">
+                  <span class="channel-filter__title">Channel Presets</span>
+                  <button type="button" id="channel-filter-clear" class="channel-filter__clear" disabled>
+                    Clear
+                  </button>
+                </div>
+                <div
+                  id="channel-filter-groups"
+                  class="channel-filter__groups"
+                  role="group"
+                  aria-label="Channel preset groups"
+                ></div>
+              </div>
+            </div>
+          </header>
           <div class="table-wrapper">
             <div class="actions-grid" role="grid" aria-label="Lighting steps timeline">
               <div class="actions-grid__header" role="row">

--- a/app.py
+++ b/app.py
@@ -180,6 +180,7 @@ def sanitize_channel_preset(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
     if not isinstance(preset_id, str) or not preset_id:
         preset_id = _generate_channel_preset_id("preset")
     name = raw.get("name") if isinstance(raw.get("name"), str) else ""
+    group = raw.get("group") if isinstance(raw.get("group"), str) else ""
     try:
         channel_value = int(raw.get("channel", 1))
     except (TypeError, ValueError):
@@ -191,7 +192,13 @@ def sanitize_channel_preset(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         values = filter(None, (sanitize_channel_value(entry) for entry in values_raw))
     else:
         values = []
-    return {"id": preset_id, "name": name, "channel": channel, "values": list(values)}
+    return {
+        "id": preset_id,
+        "name": name,
+        "group": group,
+        "channel": channel,
+        "values": list(values),
+    }
 
 
 def load_channel_presets_from_disk() -> List[Dict[str, Any]]:

--- a/channel_presets.json
+++ b/channel_presets.json
@@ -3,585 +3,1521 @@
     {
       "id": "left-light-dimmer",
       "name": "Left Light - Dimmer",
+      "group": "Left Light",
       "channel": 1,
       "values": [
-        { "id": "left-light-dimmer-off", "name": "Off", "value": 0 },
-        { "id": "left-light-dimmer-dimmed", "name": "Dimmed", "value": 63 },
-        { "id": "left-light-dimmer-normal", "name": "Normal", "value": 127 },
-        { "id": "left-light-dimmer-bright", "name": "Bright", "value": 192 },
-        { "id": "left-light-dimmer-full", "name": "Full", "value": 255 }
+        {
+          "id": "left-light-dimmer-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "left-light-dimmer-dimmed",
+          "name": "Dimmed",
+          "value": 63
+        },
+        {
+          "id": "left-light-dimmer-normal",
+          "name": "Normal",
+          "value": 127
+        },
+        {
+          "id": "left-light-dimmer-bright",
+          "name": "Bright",
+          "value": 192
+        },
+        {
+          "id": "left-light-dimmer-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "left-light-red",
       "name": "Left Light - Red",
+      "group": "Left Light",
       "channel": 2,
       "values": [
-        { "id": "left-light-red-off", "name": "Off", "value": 0 },
-        { "id": "left-light-red-full", "name": "Full", "value": 255 }
+        {
+          "id": "left-light-red-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "left-light-red-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "left-light-green",
       "name": "Left Light - Green",
+      "group": "Left Light",
       "channel": 3,
       "values": [
-        { "id": "left-light-green-off", "name": "Off", "value": 0 },
-        { "id": "left-light-green-full", "name": "Full", "value": 255 }
+        {
+          "id": "left-light-green-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "left-light-green-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "left-light-blue",
       "name": "Left Light - Blue",
+      "group": "Left Light",
       "channel": 4,
       "values": [
-        { "id": "left-light-blue-off", "name": "Off", "value": 0 },
-        { "id": "left-light-blue-full", "name": "Full", "value": 255 }
+        {
+          "id": "left-light-blue-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "left-light-blue-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "left-light-white",
       "name": "Left Light - White",
+      "group": "Left Light",
       "channel": 5,
       "values": [
-        { "id": "left-light-white-off", "name": "Off", "value": 0 },
-        { "id": "left-light-white-full", "name": "Full", "value": 255 }
+        {
+          "id": "left-light-white-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "left-light-white-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "left-light-strobe",
       "name": "Left Light - Strobe",
+      "group": "Left Light",
       "channel": 6,
       "values": [
-        { "id": "left-light-strobe-none", "name": "No Strobe", "value": 0 },
-        { "id": "left-light-strobe-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "left-light-strobe-slow", "name": "Slow", "value": 100 },
-        { "id": "left-light-strobe-medium", "name": "Medium", "value": 150 },
-        { "id": "left-light-strobe-fast", "name": "Fast", "value": 200 },
-        { "id": "left-light-strobe-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "left-light-strobe-none",
+          "name": "No Strobe",
+          "value": 0
+        },
+        {
+          "id": "left-light-strobe-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "left-light-strobe-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "left-light-strobe-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "left-light-strobe-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "left-light-strobe-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "left-light-effects",
       "name": "Left Light - Effects",
+      "group": "Left Light",
       "channel": 7,
       "values": [
-        { "id": "left-light-effects-none", "name": "No Effect", "value": 0 },
-        { "id": "left-light-effects-different-colors", "name": "Different Colors", "value": 51 },
-        { "id": "left-light-effects-color-jump", "name": "Color Jump", "value": 101 },
-        { "id": "left-light-effects-color-gradient", "name": "Color Gradient", "value": 151 },
-        { "id": "left-light-effects-color-pulse", "name": "Color Pulse", "value": 201 },
-        { "id": "left-light-effects-sound-mode", "name": "Sound Mode", "value": 251 }
+        {
+          "id": "left-light-effects-none",
+          "name": "No Effect",
+          "value": 0
+        },
+        {
+          "id": "left-light-effects-different-colors",
+          "name": "Different Colors",
+          "value": 51
+        },
+        {
+          "id": "left-light-effects-color-jump",
+          "name": "Color Jump",
+          "value": 101
+        },
+        {
+          "id": "left-light-effects-color-gradient",
+          "name": "Color Gradient",
+          "value": 151
+        },
+        {
+          "id": "left-light-effects-color-pulse",
+          "name": "Color Pulse",
+          "value": 201
+        },
+        {
+          "id": "left-light-effects-sound-mode",
+          "name": "Sound Mode",
+          "value": 251
+        }
       ]
     },
     {
       "id": "left-light-effect-speed",
       "name": "Left Light - Effect Speed",
+      "group": "Left Light",
       "channel": 8,
       "values": [
-        { "id": "left-light-effect-speed-none", "name": "None", "value": 0 },
-        { "id": "left-light-effect-speed-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "left-light-effect-speed-slow", "name": "Slow", "value": 100 },
-        { "id": "left-light-effect-speed-medium", "name": "Medium", "value": 150 },
-        { "id": "left-light-effect-speed-fast", "name": "Fast", "value": 200 },
-        { "id": "left-light-effect-speed-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "left-light-effect-speed-none",
+          "name": "None",
+          "value": 0
+        },
+        {
+          "id": "left-light-effect-speed-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "left-light-effect-speed-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "left-light-effect-speed-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "left-light-effect-speed-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "left-light-effect-speed-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "right-light-dimmer",
       "name": "Right Light - Dimmer",
+      "group": "Right Light",
       "channel": 10,
       "values": [
-        { "id": "right-light-dimmer-off", "name": "Off", "value": 0 },
-        { "id": "right-light-dimmer-dimmed", "name": "Dimmed", "value": 63 },
-        { "id": "right-light-dimmer-normal", "name": "Normal", "value": 127 },
-        { "id": "right-light-dimmer-bright", "name": "Bright", "value": 192 },
-        { "id": "right-light-dimmer-full", "name": "Full", "value": 255 }
+        {
+          "id": "right-light-dimmer-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "right-light-dimmer-dimmed",
+          "name": "Dimmed",
+          "value": 63
+        },
+        {
+          "id": "right-light-dimmer-normal",
+          "name": "Normal",
+          "value": 127
+        },
+        {
+          "id": "right-light-dimmer-bright",
+          "name": "Bright",
+          "value": 192
+        },
+        {
+          "id": "right-light-dimmer-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "right-light-red",
       "name": "Right Light - Red",
+      "group": "Right Light",
       "channel": 11,
       "values": [
-        { "id": "right-light-red-off", "name": "Off", "value": 0 },
-        { "id": "right-light-red-full", "name": "Full", "value": 255 }
+        {
+          "id": "right-light-red-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "right-light-red-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "right-light-green",
       "name": "Right Light - Green",
+      "group": "Right Light",
       "channel": 12,
       "values": [
-        { "id": "right-light-green-off", "name": "Off", "value": 0 },
-        { "id": "right-light-green-full", "name": "Full", "value": 255 }
+        {
+          "id": "right-light-green-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "right-light-green-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "right-light-blue",
       "name": "Right Light - Blue",
+      "group": "Right Light",
       "channel": 13,
       "values": [
-        { "id": "right-light-blue-off", "name": "Off", "value": 0 },
-        { "id": "right-light-blue-full", "name": "Full", "value": 255 }
+        {
+          "id": "right-light-blue-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "right-light-blue-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "right-light-white",
       "name": "Right Light - White",
+      "group": "Right Light",
       "channel": 14,
       "values": [
-        { "id": "right-light-white-off", "name": "Off", "value": 0 },
-        { "id": "right-light-white-full", "name": "Full", "value": 255 }
+        {
+          "id": "right-light-white-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "right-light-white-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "right-light-strobe",
       "name": "Right Light - Strobe",
+      "group": "Right Light",
       "channel": 15,
       "values": [
-        { "id": "right-light-strobe-none", "name": "No Strobe", "value": 0 },
-        { "id": "right-light-strobe-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "right-light-strobe-slow", "name": "Slow", "value": 100 },
-        { "id": "right-light-strobe-medium", "name": "Medium", "value": 150 },
-        { "id": "right-light-strobe-fast", "name": "Fast", "value": 200 },
-        { "id": "right-light-strobe-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "right-light-strobe-none",
+          "name": "No Strobe",
+          "value": 0
+        },
+        {
+          "id": "right-light-strobe-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "right-light-strobe-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "right-light-strobe-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "right-light-strobe-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "right-light-strobe-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "right-light-effects",
       "name": "Right Light - Effects",
+      "group": "Right Light",
       "channel": 16,
       "values": [
-        { "id": "right-light-effects-none", "name": "No Effect", "value": 0 },
-        { "id": "right-light-effects-different-colors", "name": "Different Colors", "value": 51 },
-        { "id": "right-light-effects-color-jump", "name": "Color Jump", "value": 101 },
-        { "id": "right-light-effects-color-gradient", "name": "Color Gradient", "value": 151 },
-        { "id": "right-light-effects-color-pulse", "name": "Color Pulse", "value": 201 },
-        { "id": "right-light-effects-sound-mode", "name": "Sound Mode", "value": 251 }
+        {
+          "id": "right-light-effects-none",
+          "name": "No Effect",
+          "value": 0
+        },
+        {
+          "id": "right-light-effects-different-colors",
+          "name": "Different Colors",
+          "value": 51
+        },
+        {
+          "id": "right-light-effects-color-jump",
+          "name": "Color Jump",
+          "value": 101
+        },
+        {
+          "id": "right-light-effects-color-gradient",
+          "name": "Color Gradient",
+          "value": 151
+        },
+        {
+          "id": "right-light-effects-color-pulse",
+          "name": "Color Pulse",
+          "value": 201
+        },
+        {
+          "id": "right-light-effects-sound-mode",
+          "name": "Sound Mode",
+          "value": 251
+        }
       ]
     },
     {
       "id": "right-light-effect-speed",
       "name": "Right Light - Effect Speed",
+      "group": "Right Light",
       "channel": 17,
       "values": [
-        { "id": "right-light-effect-speed-none", "name": "None", "value": 0 },
-        { "id": "right-light-effect-speed-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "right-light-effect-speed-slow", "name": "Slow", "value": 100 },
-        { "id": "right-light-effect-speed-medium", "name": "Medium", "value": 150 },
-        { "id": "right-light-effect-speed-fast", "name": "Fast", "value": 200 },
-        { "id": "right-light-effect-speed-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "right-light-effect-speed-none",
+          "name": "None",
+          "value": 0
+        },
+        {
+          "id": "right-light-effect-speed-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "right-light-effect-speed-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "right-light-effect-speed-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "right-light-effect-speed-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "right-light-effect-speed-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "back-light-dimmer",
       "name": "Back Light - Dimmer",
+      "group": "Back Light",
       "channel": 20,
       "values": [
-        { "id": "back-light-dimmer-off", "name": "Off", "value": 0 },
-        { "id": "back-light-dimmer-dimmed", "name": "Dimmed", "value": 63 },
-        { "id": "back-light-dimmer-normal", "name": "Normal", "value": 127 },
-        { "id": "back-light-dimmer-bright", "name": "Bright", "value": 192 },
-        { "id": "back-light-dimmer-full", "name": "Full", "value": 255 }
+        {
+          "id": "back-light-dimmer-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "back-light-dimmer-dimmed",
+          "name": "Dimmed",
+          "value": 63
+        },
+        {
+          "id": "back-light-dimmer-normal",
+          "name": "Normal",
+          "value": 127
+        },
+        {
+          "id": "back-light-dimmer-bright",
+          "name": "Bright",
+          "value": 192
+        },
+        {
+          "id": "back-light-dimmer-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "back-light-red",
       "name": "Back Light - Red",
+      "group": "Back Light",
       "channel": 21,
       "values": [
-        { "id": "back-light-red-off", "name": "Off", "value": 0 },
-        { "id": "back-light-red-full", "name": "Full", "value": 255 }
+        {
+          "id": "back-light-red-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "back-light-red-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "back-light-green",
       "name": "Back Light - Green",
+      "group": "Back Light",
       "channel": 22,
       "values": [
-        { "id": "back-light-green-off", "name": "Off", "value": 0 },
-        { "id": "back-light-green-full", "name": "Full", "value": 255 }
+        {
+          "id": "back-light-green-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "back-light-green-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "back-light-blue",
       "name": "Back Light - Blue",
+      "group": "Back Light",
       "channel": 23,
       "values": [
-        { "id": "back-light-blue-off", "name": "Off", "value": 0 },
-        { "id": "back-light-blue-full", "name": "Full", "value": 255 }
+        {
+          "id": "back-light-blue-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "back-light-blue-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "back-light-white",
       "name": "Back Light - White",
+      "group": "Back Light",
       "channel": 24,
       "values": [
-        { "id": "back-light-white-off", "name": "Off", "value": 0 },
-        { "id": "back-light-white-full", "name": "Full", "value": 255 }
+        {
+          "id": "back-light-white-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "back-light-white-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "back-light-strobe",
       "name": "Back Light - Strobe",
+      "group": "Back Light",
       "channel": 25,
       "values": [
-        { "id": "back-light-strobe-none", "name": "No Strobe", "value": 0 },
-        { "id": "back-light-strobe-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "back-light-strobe-slow", "name": "Slow", "value": 100 },
-        { "id": "back-light-strobe-medium", "name": "Medium", "value": 150 },
-        { "id": "back-light-strobe-fast", "name": "Fast", "value": 200 },
-        { "id": "back-light-strobe-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "back-light-strobe-none",
+          "name": "No Strobe",
+          "value": 0
+        },
+        {
+          "id": "back-light-strobe-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "back-light-strobe-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "back-light-strobe-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "back-light-strobe-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "back-light-strobe-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "back-light-effects",
       "name": "Back Light - Effects",
+      "group": "Back Light",
       "channel": 26,
       "values": [
-        { "id": "back-light-effects-none", "name": "No Effect", "value": 0 },
-        { "id": "back-light-effects-different-colors", "name": "Different Colors", "value": 51 },
-        { "id": "back-light-effects-color-jump", "name": "Color Jump", "value": 101 },
-        { "id": "back-light-effects-color-gradient", "name": "Color Gradient", "value": 151 },
-        { "id": "back-light-effects-color-pulse", "name": "Color Pulse", "value": 201 },
-        { "id": "back-light-effects-sound-mode", "name": "Sound Mode", "value": 251 }
+        {
+          "id": "back-light-effects-none",
+          "name": "No Effect",
+          "value": 0
+        },
+        {
+          "id": "back-light-effects-different-colors",
+          "name": "Different Colors",
+          "value": 51
+        },
+        {
+          "id": "back-light-effects-color-jump",
+          "name": "Color Jump",
+          "value": 101
+        },
+        {
+          "id": "back-light-effects-color-gradient",
+          "name": "Color Gradient",
+          "value": 151
+        },
+        {
+          "id": "back-light-effects-color-pulse",
+          "name": "Color Pulse",
+          "value": 201
+        },
+        {
+          "id": "back-light-effects-sound-mode",
+          "name": "Sound Mode",
+          "value": 251
+        }
       ]
     },
     {
       "id": "back-light-effect-speed",
       "name": "Back Light - Effect Speed",
+      "group": "Back Light",
       "channel": 27,
       "values": [
-        { "id": "back-light-effect-speed-none", "name": "None", "value": 0 },
-        { "id": "back-light-effect-speed-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "back-light-effect-speed-slow", "name": "Slow", "value": 100 },
-        { "id": "back-light-effect-speed-medium", "name": "Medium", "value": 150 },
-        { "id": "back-light-effect-speed-fast", "name": "Fast", "value": 200 },
-        { "id": "back-light-effect-speed-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "back-light-effect-speed-none",
+          "name": "None",
+          "value": 0
+        },
+        {
+          "id": "back-light-effect-speed-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "back-light-effect-speed-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "back-light-effect-speed-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "back-light-effect-speed-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "back-light-effect-speed-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "front-light-dimmer",
       "name": "Front Light - Dimmer",
+      "group": "Front Light",
       "channel": 30,
       "values": [
-        { "id": "front-light-dimmer-off", "name": "Off", "value": 0 },
-        { "id": "front-light-dimmer-dimmed", "name": "Dimmed", "value": 63 },
-        { "id": "front-light-dimmer-normal", "name": "Normal", "value": 127 },
-        { "id": "front-light-dimmer-bright", "name": "Bright", "value": 192 },
-        { "id": "front-light-dimmer-full", "name": "Full", "value": 255 }
+        {
+          "id": "front-light-dimmer-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "front-light-dimmer-dimmed",
+          "name": "Dimmed",
+          "value": 63
+        },
+        {
+          "id": "front-light-dimmer-normal",
+          "name": "Normal",
+          "value": 127
+        },
+        {
+          "id": "front-light-dimmer-bright",
+          "name": "Bright",
+          "value": 192
+        },
+        {
+          "id": "front-light-dimmer-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "front-light-red",
       "name": "Front Light - Red",
+      "group": "Front Light",
       "channel": 31,
       "values": [
-        { "id": "front-light-red-off", "name": "Off", "value": 0 },
-        { "id": "front-light-red-full", "name": "Full", "value": 255 }
+        {
+          "id": "front-light-red-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "front-light-red-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "front-light-green",
       "name": "Front Light - Green",
+      "group": "Front Light",
       "channel": 32,
       "values": [
-        { "id": "front-light-green-off", "name": "Off", "value": 0 },
-        { "id": "front-light-green-full", "name": "Full", "value": 255 }
+        {
+          "id": "front-light-green-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "front-light-green-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "front-light-blue",
       "name": "Front Light - Blue",
+      "group": "Front Light",
       "channel": 33,
       "values": [
-        { "id": "front-light-blue-off", "name": "Off", "value": 0 },
-        { "id": "front-light-blue-full", "name": "Full", "value": 255 }
+        {
+          "id": "front-light-blue-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "front-light-blue-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "front-light-white",
       "name": "Front Light - White",
+      "group": "Front Light",
       "channel": 34,
       "values": [
-        { "id": "front-light-white-off", "name": "Off", "value": 0 },
-        { "id": "front-light-white-full", "name": "Full", "value": 255 }
+        {
+          "id": "front-light-white-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "front-light-white-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "front-light-strobe",
       "name": "Front Light - Strobe",
+      "group": "Front Light",
       "channel": 35,
       "values": [
-        { "id": "front-light-strobe-none", "name": "No Strobe", "value": 0 },
-        { "id": "front-light-strobe-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "front-light-strobe-slow", "name": "Slow", "value": 100 },
-        { "id": "front-light-strobe-medium", "name": "Medium", "value": 150 },
-        { "id": "front-light-strobe-fast", "name": "Fast", "value": 200 },
-        { "id": "front-light-strobe-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "front-light-strobe-none",
+          "name": "No Strobe",
+          "value": 0
+        },
+        {
+          "id": "front-light-strobe-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "front-light-strobe-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "front-light-strobe-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "front-light-strobe-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "front-light-strobe-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "front-light-effects",
       "name": "Front Light - Effects",
+      "group": "Front Light",
       "channel": 36,
       "values": [
-        { "id": "front-light-effects-none", "name": "No Effect", "value": 0 },
-        { "id": "front-light-effects-different-colors", "name": "Different Colors", "value": 51 },
-        { "id": "front-light-effects-color-jump", "name": "Color Jump", "value": 101 },
-        { "id": "front-light-effects-color-gradient", "name": "Color Gradient", "value": 151 },
-        { "id": "front-light-effects-color-pulse", "name": "Color Pulse", "value": 201 },
-        { "id": "front-light-effects-sound-mode", "name": "Sound Mode", "value": 251 }
+        {
+          "id": "front-light-effects-none",
+          "name": "No Effect",
+          "value": 0
+        },
+        {
+          "id": "front-light-effects-different-colors",
+          "name": "Different Colors",
+          "value": 51
+        },
+        {
+          "id": "front-light-effects-color-jump",
+          "name": "Color Jump",
+          "value": 101
+        },
+        {
+          "id": "front-light-effects-color-gradient",
+          "name": "Color Gradient",
+          "value": 151
+        },
+        {
+          "id": "front-light-effects-color-pulse",
+          "name": "Color Pulse",
+          "value": 201
+        },
+        {
+          "id": "front-light-effects-sound-mode",
+          "name": "Sound Mode",
+          "value": 251
+        }
       ]
     },
     {
       "id": "front-light-effect-speed",
       "name": "Front Light - Effect Speed",
+      "group": "Front Light",
       "channel": 37,
       "values": [
-        { "id": "front-light-effect-speed-none", "name": "None", "value": 0 },
-        { "id": "front-light-effect-speed-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "front-light-effect-speed-slow", "name": "Slow", "value": 100 },
-        { "id": "front-light-effect-speed-medium", "name": "Medium", "value": 150 },
-        { "id": "front-light-effect-speed-fast", "name": "Fast", "value": 200 },
-        { "id": "front-light-effect-speed-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "front-light-effect-speed-none",
+          "name": "None",
+          "value": 0
+        },
+        {
+          "id": "front-light-effect-speed-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "front-light-effect-speed-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "front-light-effect-speed-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "front-light-effect-speed-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "front-light-effect-speed-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-rotation",
       "name": "Mover Light - Rotation",
+      "group": "Movers",
       "channel": 40,
       "values": [
-        { "id": "mover-light-rotation-0", "name": "0°", "value": 0 },
-        { "id": "mover-light-rotation-45", "name": "45°", "value": 23 },
-        { "id": "mover-light-rotation-90", "name": "90°", "value": 46 },
-        { "id": "mover-light-rotation-135", "name": "135°", "value": 69 },
-        { "id": "mover-light-rotation-180", "name": "180°", "value": 92 },
-        { "id": "mover-light-rotation-225", "name": "225°", "value": 115 },
-        { "id": "mover-light-rotation-270", "name": "270°", "value": 138 },
-        { "id": "mover-light-rotation-360", "name": "360°", "value": 161 },
-        { "id": "mover-light-rotation-405", "name": "405°", "value": 184 },
-        { "id": "mover-light-rotation-450", "name": "450°", "value": 207 },
-        { "id": "mover-light-rotation-495", "name": "495°", "value": 230 },
-        { "id": "mover-light-rotation-540", "name": "540°", "value": 255 }
+        {
+          "id": "mover-light-rotation-0",
+          "name": "0\u00b0",
+          "value": 0
+        },
+        {
+          "id": "mover-light-rotation-45",
+          "name": "45\u00b0",
+          "value": 23
+        },
+        {
+          "id": "mover-light-rotation-90",
+          "name": "90\u00b0",
+          "value": 46
+        },
+        {
+          "id": "mover-light-rotation-135",
+          "name": "135\u00b0",
+          "value": 69
+        },
+        {
+          "id": "mover-light-rotation-180",
+          "name": "180\u00b0",
+          "value": 92
+        },
+        {
+          "id": "mover-light-rotation-225",
+          "name": "225\u00b0",
+          "value": 115
+        },
+        {
+          "id": "mover-light-rotation-270",
+          "name": "270\u00b0",
+          "value": 138
+        },
+        {
+          "id": "mover-light-rotation-360",
+          "name": "360\u00b0",
+          "value": 161
+        },
+        {
+          "id": "mover-light-rotation-405",
+          "name": "405\u00b0",
+          "value": 184
+        },
+        {
+          "id": "mover-light-rotation-450",
+          "name": "450\u00b0",
+          "value": 207
+        },
+        {
+          "id": "mover-light-rotation-495",
+          "name": "495\u00b0",
+          "value": 230
+        },
+        {
+          "id": "mover-light-rotation-540",
+          "name": "540\u00b0",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-rotation-speed",
       "name": "Mover Light - Rotation Speed",
+      "group": "Movers",
       "channel": 41,
       "values": [
-        { "id": "mover-light-rotation-speed-none", "name": "None", "value": 0 },
-        { "id": "mover-light-rotation-speed-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "mover-light-rotation-speed-slow", "name": "Slow", "value": 100 },
-        { "id": "mover-light-rotation-speed-medium", "name": "Medium", "value": 150 },
-        { "id": "mover-light-rotation-speed-fast", "name": "Fast", "value": 200 },
-        { "id": "mover-light-rotation-speed-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "mover-light-rotation-speed-none",
+          "name": "None",
+          "value": 0
+        },
+        {
+          "id": "mover-light-rotation-speed-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "mover-light-rotation-speed-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "mover-light-rotation-speed-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "mover-light-rotation-speed-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "mover-light-rotation-speed-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-pattern-rotation",
       "name": "Mover Light - Pattern Rotation",
+      "group": "Movers",
       "channel": 42,
       "values": [
-        { "id": "mover-light-pattern-rotation-0", "name": "0°", "value": 0 },
-        { "id": "mover-light-pattern-rotation-45", "name": "45°", "value": 31 },
-        { "id": "mover-light-pattern-rotation-90", "name": "90°", "value": 62 },
-        { "id": "mover-light-pattern-rotation-135", "name": "135°", "value": 93 },
-        { "id": "mover-light-pattern-rotation-180", "name": "180°", "value": 127 },
-        { "id": "mover-light-pattern-rotation-rotate-slow", "name": "Rotate Slow", "value": 128 },
-        { "id": "mover-light-pattern-rotation-rotate-medium", "name": "Rotate Medium", "value": 159 },
-        { "id": "mover-light-pattern-rotation-rotate-fast", "name": "Rotate Fast", "value": 191 },
-        { "id": "mover-light-pattern-rotation-reverse-slow", "name": "Reverse Slow", "value": 192 },
-        { "id": "mover-light-pattern-rotation-reverse-medium", "name": "Reverse Medium", "value": 223 },
-        { "id": "mover-light-pattern-rotation-reverse-fast", "name": "Reverse Fast", "value": 255 }
+        {
+          "id": "mover-light-pattern-rotation-0",
+          "name": "0\u00b0",
+          "value": 0
+        },
+        {
+          "id": "mover-light-pattern-rotation-45",
+          "name": "45\u00b0",
+          "value": 31
+        },
+        {
+          "id": "mover-light-pattern-rotation-90",
+          "name": "90\u00b0",
+          "value": 62
+        },
+        {
+          "id": "mover-light-pattern-rotation-135",
+          "name": "135\u00b0",
+          "value": 93
+        },
+        {
+          "id": "mover-light-pattern-rotation-180",
+          "name": "180\u00b0",
+          "value": 127
+        },
+        {
+          "id": "mover-light-pattern-rotation-rotate-slow",
+          "name": "Rotate Slow",
+          "value": 128
+        },
+        {
+          "id": "mover-light-pattern-rotation-rotate-medium",
+          "name": "Rotate Medium",
+          "value": 159
+        },
+        {
+          "id": "mover-light-pattern-rotation-rotate-fast",
+          "name": "Rotate Fast",
+          "value": 191
+        },
+        {
+          "id": "mover-light-pattern-rotation-reverse-slow",
+          "name": "Reverse Slow",
+          "value": 192
+        },
+        {
+          "id": "mover-light-pattern-rotation-reverse-medium",
+          "name": "Reverse Medium",
+          "value": 223
+        },
+        {
+          "id": "mover-light-pattern-rotation-reverse-fast",
+          "name": "Reverse Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam1-rotation",
       "name": "Mover Light - Beam 1 Rotation",
+      "group": "Movers",
       "channel": 43,
       "values": [
-        { "id": "mover-light-beam-rotation-0", "name": "0°", "value": 0 },
-        { "id": "mover-light-beam-rotation-45", "name": "45°", "value": 63 },
-        { "id": "mover-light-beam-rotation-90", "name": "90°", "value": 127 },
-        { "id": "mover-light-beam-rotation-135", "name": "135°", "value": 192 },
-        { "id": "mover-light-beam-rotation-180", "name": "180°", "value": 255 }
+        {
+          "id": "mover-light-beam-rotation-0",
+          "name": "0\u00b0",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam-rotation-45",
+          "name": "45\u00b0",
+          "value": 63
+        },
+        {
+          "id": "mover-light-beam-rotation-90",
+          "name": "90\u00b0",
+          "value": 127
+        },
+        {
+          "id": "mover-light-beam-rotation-135",
+          "name": "135\u00b0",
+          "value": 192
+        },
+        {
+          "id": "mover-light-beam-rotation-180",
+          "name": "180\u00b0",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam2-rotation",
       "name": "Mover Light - Beam 2 Rotation",
+      "group": "Movers",
       "channel": 44,
       "values": [
-        { "id": "mover-light-beam2-rotation-0", "name": "0°", "value": 0 },
-        { "id": "mover-light-beam2-rotation-45", "name": "45°", "value": 63 },
-        { "id": "mover-light-beam2-rotation-90", "name": "90°", "value": 127 },
-        { "id": "mover-light-beam2-rotation-135", "name": "135°", "value": 192 },
-        { "id": "mover-light-beam2-rotation-180", "name": "180°", "value": 255 }
+        {
+          "id": "mover-light-beam2-rotation-0",
+          "name": "0\u00b0",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam2-rotation-45",
+          "name": "45\u00b0",
+          "value": 63
+        },
+        {
+          "id": "mover-light-beam2-rotation-90",
+          "name": "90\u00b0",
+          "value": 127
+        },
+        {
+          "id": "mover-light-beam2-rotation-135",
+          "name": "135\u00b0",
+          "value": 192
+        },
+        {
+          "id": "mover-light-beam2-rotation-180",
+          "name": "180\u00b0",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam3-rotation",
       "name": "Mover Light - Beam 3 Rotation",
+      "group": "Movers",
       "channel": 45,
       "values": [
-        { "id": "mover-light-beam3-rotation-0", "name": "0°", "value": 0 },
-        { "id": "mover-light-beam3-rotation-45", "name": "45°", "value": 63 },
-        { "id": "mover-light-beam3-rotation-90", "name": "90°", "value": 127 },
-        { "id": "mover-light-beam3-rotation-135", "name": "135°", "value": 192 },
-        { "id": "mover-light-beam3-rotation-180", "name": "180°", "value": 255 }
+        {
+          "id": "mover-light-beam3-rotation-0",
+          "name": "0\u00b0",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam3-rotation-45",
+          "name": "45\u00b0",
+          "value": 63
+        },
+        {
+          "id": "mover-light-beam3-rotation-90",
+          "name": "90\u00b0",
+          "value": 127
+        },
+        {
+          "id": "mover-light-beam3-rotation-135",
+          "name": "135\u00b0",
+          "value": 192
+        },
+        {
+          "id": "mover-light-beam3-rotation-180",
+          "name": "180\u00b0",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam4-rotation",
       "name": "Mover Light - Beam 4 Rotation",
+      "group": "Movers",
       "channel": 46,
       "values": [
-        { "id": "mover-light-beam4-rotation-0", "name": "0°", "value": 0 },
-        { "id": "mover-light-beam4-rotation-45", "name": "45°", "value": 63 },
-        { "id": "mover-light-beam4-rotation-90", "name": "90°", "value": 127 },
-        { "id": "mover-light-beam4-rotation-135", "name": "135°", "value": 192 },
-        { "id": "mover-light-beam4-rotation-180", "name": "180°", "value": 255 }
+        {
+          "id": "mover-light-beam4-rotation-0",
+          "name": "0\u00b0",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam4-rotation-45",
+          "name": "45\u00b0",
+          "value": 63
+        },
+        {
+          "id": "mover-light-beam4-rotation-90",
+          "name": "90\u00b0",
+          "value": 127
+        },
+        {
+          "id": "mover-light-beam4-rotation-135",
+          "name": "135\u00b0",
+          "value": 192
+        },
+        {
+          "id": "mover-light-beam4-rotation-180",
+          "name": "180\u00b0",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam-brightness",
       "name": "Mover Light - Beam Brightness",
+      "group": "Movers",
       "channel": 47,
       "values": [
-        { "id": "mover-light-beam-brightness-off", "name": "Off", "value": 0 },
-        { "id": "mover-light-beam-brightness-dimmed", "name": "Dimmed", "value": 63 },
-        { "id": "mover-light-beam-brightness-normal", "name": "Normal", "value": 127 },
-        { "id": "mover-light-beam-brightness-bright", "name": "Bright", "value": 192 },
-        { "id": "mover-light-beam-brightness-full", "name": "Full", "value": 255 }
+        {
+          "id": "mover-light-beam-brightness-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam-brightness-dimmed",
+          "name": "Dimmed",
+          "value": 63
+        },
+        {
+          "id": "mover-light-beam-brightness-normal",
+          "name": "Normal",
+          "value": 127
+        },
+        {
+          "id": "mover-light-beam-brightness-bright",
+          "name": "Bright",
+          "value": 192
+        },
+        {
+          "id": "mover-light-beam-brightness-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-strobe",
       "name": "Mover Light - Strobe",
+      "group": "Movers",
       "channel": 48,
       "values": [
-        { "id": "mover-light-strobe-none", "name": "No Strobe", "value": 0 },
-        { "id": "mover-light-strobe-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "mover-light-strobe-slow", "name": "Slow", "value": 100 },
-        { "id": "mover-light-strobe-medium", "name": "Medium", "value": 150 },
-        { "id": "mover-light-strobe-fast", "name": "Fast", "value": 200 },
-        { "id": "mover-light-strobe-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "mover-light-strobe-none",
+          "name": "No Strobe",
+          "value": 0
+        },
+        {
+          "id": "mover-light-strobe-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "mover-light-strobe-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "mover-light-strobe-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "mover-light-strobe-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "mover-light-strobe-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam-red",
       "name": "Mover Light - Beam Red",
+      "group": "Movers",
       "channel": 49,
       "values": [
-        { "id": "mover-light-beam-red-off", "name": "Off", "value": 0 },
-        { "id": "mover-light-beam-red-full", "name": "Full", "value": 255 }
+        {
+          "id": "mover-light-beam-red-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam-red-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam-green",
       "name": "Mover Light - Beam Green",
+      "group": "Movers",
       "channel": 50,
       "values": [
-        { "id": "mover-light-beam-green-off", "name": "Off", "value": 0 },
-        { "id": "mover-light-beam-green-full", "name": "Full", "value": 255 }
+        {
+          "id": "mover-light-beam-green-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam-green-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam-blue",
       "name": "Mover Light - Beam Blue",
+      "group": "Movers",
       "channel": 51,
       "values": [
-        { "id": "mover-light-beam-blue-off", "name": "Off", "value": 0 },
-        { "id": "mover-light-beam-blue-full", "name": "Full", "value": 255 }
+        {
+          "id": "mover-light-beam-blue-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam-blue-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-beam-white",
       "name": "Mover Light - Beam White",
+      "group": "Movers",
       "channel": 52,
       "values": [
-        { "id": "mover-light-beam-white-off", "name": "Off", "value": 0 },
-        { "id": "mover-light-beam-white-full", "name": "Full", "value": 255 }
+        {
+          "id": "mover-light-beam-white-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "mover-light-beam-white-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-laser-pattern",
       "name": "Mover Light - Laser Pattern",
+      "group": "Movers",
       "channel": 53,
       "values": []
     },
     {
       "id": "mover-light-laser-red",
       "name": "Mover Light - Laser Red",
+      "group": "Movers",
       "channel": 54,
       "values": [
-        { "id": "mover-light-laser-red-off", "name": "Off", "value": 0 },
-        { "id": "mover-light-laser-red-full", "name": "Full", "value": 255 }
+        {
+          "id": "mover-light-laser-red-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "mover-light-laser-red-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-laser-green",
       "name": "Mover Light - Laser Green",
+      "group": "Movers",
       "channel": 55,
       "values": [
-        { "id": "mover-light-laser-green-off", "name": "Off", "value": 0 },
-        { "id": "mover-light-laser-green-full", "name": "Full", "value": 255 }
+        {
+          "id": "mover-light-laser-green-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "mover-light-laser-green-full",
+          "name": "Full",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-white-flash",
       "name": "Mover Light - White Flash",
+      "group": "Movers",
       "channel": 56,
       "values": [
-        { "id": "mover-light-white-flash-none", "name": "No Flash", "value": 0 },
-        { "id": "mover-light-white-flash-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "mover-light-white-flash-slow", "name": "Slow", "value": 100 },
-        { "id": "mover-light-white-flash-medium", "name": "Medium", "value": 150 },
-        { "id": "mover-light-white-flash-fast", "name": "Fast", "value": 200 },
-        { "id": "mover-light-white-flash-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "mover-light-white-flash-none",
+          "name": "No Flash",
+          "value": 0
+        },
+        {
+          "id": "mover-light-white-flash-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "mover-light-white-flash-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "mover-light-white-flash-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "mover-light-white-flash-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "mover-light-white-flash-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-strip",
       "name": "Mover Light - Light Strip",
+      "group": "Movers",
       "channel": 57,
       "values": [
-        { "id": "mover-light-strip-off", "name": "Off", "value": 0 },
-        { "id": "mover-light-strip-red", "name": "Red", "value": 13 },
-        { "id": "mover-light-strip-green", "name": "Green", "value": 22 },
-        { "id": "mover-light-strip-blue", "name": "Blue", "value": 31 },
-        { "id": "mover-light-strip-yellow", "name": "Yellow", "value": 40 },
-        { "id": "mover-light-strip-purple", "name": "Purple", "value": 49 },
-        { "id": "mover-light-strip-cyan", "name": "Cyan", "value": 58 },
-        { "id": "mover-light-strip-white", "name": "White", "value": 67 },
-        { "id": "mover-light-strip-effects", "name": "Light Effects", "value": 76 }
+        {
+          "id": "mover-light-strip-off",
+          "name": "Off",
+          "value": 0
+        },
+        {
+          "id": "mover-light-strip-red",
+          "name": "Red",
+          "value": 13
+        },
+        {
+          "id": "mover-light-strip-green",
+          "name": "Green",
+          "value": 22
+        },
+        {
+          "id": "mover-light-strip-blue",
+          "name": "Blue",
+          "value": 31
+        },
+        {
+          "id": "mover-light-strip-yellow",
+          "name": "Yellow",
+          "value": 40
+        },
+        {
+          "id": "mover-light-strip-purple",
+          "name": "Purple",
+          "value": 49
+        },
+        {
+          "id": "mover-light-strip-cyan",
+          "name": "Cyan",
+          "value": 58
+        },
+        {
+          "id": "mover-light-strip-white",
+          "name": "White",
+          "value": 67
+        },
+        {
+          "id": "mover-light-strip-effects",
+          "name": "Light Effects",
+          "value": 76
+        }
       ]
     },
     {
       "id": "mover-light-strip-strobe",
       "name": "Mover Light - Light Strip Strobe",
+      "group": "Movers",
       "channel": 58,
       "values": [
-        { "id": "mover-light-strip-strobe-none", "name": "No Strobe", "value": 0 },
-        { "id": "mover-light-strip-strobe-super-slow", "name": "Super Slow", "value": 50 },
-        { "id": "mover-light-strip-strobe-slow", "name": "Slow", "value": 100 },
-        { "id": "mover-light-strip-strobe-medium", "name": "Medium", "value": 150 },
-        { "id": "mover-light-strip-strobe-fast", "name": "Fast", "value": 200 },
-        { "id": "mover-light-strip-strobe-super-fast", "name": "Super Fast", "value": 255 }
+        {
+          "id": "mover-light-strip-strobe-none",
+          "name": "No Strobe",
+          "value": 0
+        },
+        {
+          "id": "mover-light-strip-strobe-super-slow",
+          "name": "Super Slow",
+          "value": 50
+        },
+        {
+          "id": "mover-light-strip-strobe-slow",
+          "name": "Slow",
+          "value": 100
+        },
+        {
+          "id": "mover-light-strip-strobe-medium",
+          "name": "Medium",
+          "value": 150
+        },
+        {
+          "id": "mover-light-strip-strobe-fast",
+          "name": "Fast",
+          "value": 200
+        },
+        {
+          "id": "mover-light-strip-strobe-super-fast",
+          "name": "Super Fast",
+          "value": 255
+        }
       ]
     },
     {
       "id": "mover-light-effects",
       "name": "Mover Light - Effects",
+      "group": "Movers",
       "channel": 59,
       "values": [
-        { "id": "mover-light-effects-none", "name": "No", "value": 0 },
-        { "id": "mover-light-effects-stochastic", "name": "Stochastic", "value": 51 },
-        { "id": "mover-light-effects-sound-mode", "name": "Sound Mode", "value": 151 },
-        { "id": "mover-light-effects-reset", "name": "Reset", "value": 251 }
+        {
+          "id": "mover-light-effects-none",
+          "name": "No",
+          "value": 0
+        },
+        {
+          "id": "mover-light-effects-stochastic",
+          "name": "Stochastic",
+          "value": 51
+        },
+        {
+          "id": "mover-light-effects-sound-mode",
+          "name": "Sound Mode",
+          "value": 151
+        },
+        {
+          "id": "mover-light-effects-reset",
+          "name": "Reset",
+          "value": 251
+        }
       ]
     }
   ]


### PR DESCRIPTION
## Summary
- add a channel filter dropdown to the timeline header and supporting UI elements
- group channel presets in the client, enabling group assignment in preset editing and filtered action rendering
- persist the new group metadata through the backend and seed data for existing presets

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5af6f5614833281aef2e57c2fa3af