### PR TITLE
Fix persistence of delay rows in light templates

### DIFF
--- a/tests/test_light_templates.py
+++ b/tests/test_light_templates.py
@@ -1,0 +1,42 @@
+import pytest
+
+
+pytest.importorskip("flask")
+
+from app import sanitize_template_row
+
+
+def test_sanitize_template_row_action_includes_type_and_fields():
+    result = sanitize_template_row(
+        {
+            "id": "row_action",
+            "type": "action",
+            "channel": 42,
+            "value": 200,
+            "fade": 1.25,
+            "channelPresetId": "preset-1",
+            "valuePresetId": "value-1",
+        }
+    )
+
+    assert result == {
+        "id": "row_action",
+        "type": "action",
+        "channel": 42,
+        "value": 200,
+        "fade": 1.25,
+        "channelPresetId": "preset-1",
+        "valuePresetId": "value-1",
+    }
+
+
+def test_sanitize_template_row_delay_preserves_duration():
+    result = sanitize_template_row({"id": "row_delay", "type": "delay", "duration": "2.5"})
+
+    assert result == {"id": "row_delay", "type": "delay", "duration": 2.5}
+
+
+def test_sanitize_template_row_infers_delay_type_when_missing():
+    result = sanitize_template_row({"id": "row_delay", "duration": 3})
+
+    assert result == {"id": "row_delay", "type": "delay", "duration": 3.0}


### PR DESCRIPTION
## Summary
- ensure light template sanitization preserves delay rows and includes explicit row types
- add unit tests covering action and delay template row sanitization

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5b46b5d188332b645bde0587af6a7