### PR TITLE
Prevent template loop duplication when adding timeline rows

### DIFF
--- a/DMX Template Builder/builder.js
+++ b/DMX Template Builder/builder.js
@@ -1332,22 +1332,22 @@ function renderActions(options = {}) {
         }
       });
 
-      let lastTemplateInstanceId = null;
+      const renderedTemplateInstances = new Set();
       itemsToRender.forEach(({ action, index }) => {
         if (action.templateId && action.templateInstanceId) {
-          if (action.templateInstanceId !== lastTemplateInstanceId) {
-            const templateRow = createTemplateInstanceRow(
-              group,
-              action,
-              index,
-              templateCounts.get(action.templateInstanceId) || 0,
-            );
-            actionsBody.append(templateRow);
+          if (renderedTemplateInstances.has(action.templateInstanceId)) {
+            return;
           }
-          lastTemplateInstanceId = action.templateInstanceId;
+          const templateRow = createTemplateInstanceRow(
+            group,
+            action,
+            index,
+            templateCounts.get(action.templateInstanceId) || 0,
+          );
+          actionsBody.append(templateRow);
+          renderedTemplateInstances.add(action.templateInstanceId);
           return;
         }
-        lastTemplateInstanceId = null;
         const row = createActionRow(action, index, group);
         actionsBody.append(row);
       });


### PR DESCRIPTION
## Summary
- prevent duplicate template instance rows from rendering when actions are inserted into the same step by tracking which instances have already been displayed

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5b796eab48332983c133fbf77303c