### PR TITLE
Fix DMX fade starting level and preserve template offsets when retiming steps

### DIFF
--- a/DMX Template Builder/builder.js
+++ b/DMX Template Builder/builder.js
@@ -2751,13 +2751,34 @@ function handleStepTimeChange(event, stepId) {
   const formatted = secondsToTimecode(seconds);
   input.value = formatted;
 
+  const groupInfo = stepInfoById.get(stepId);
+  const previousSeconds = groupInfo ? parseTimeString(groupInfo.time) : null;
+
   let updated = false;
-  actions.forEach((action) => {
-    if (getActionStepId(action) === stepId) {
-      action.time = formatted;
+  if (previousSeconds === null) {
+    actions.forEach((action) => {
+      if (getActionStepId(action) === stepId) {
+        action.time = formatted;
+        updated = true;
+      }
+    });
+  } else {
+    const delta = seconds - previousSeconds;
+    actions.forEach((action) => {
+      if (getActionStepId(action) !== stepId) {
+        return;
+      }
+      const actionSeconds = parseTimeString(action.time);
+      if (actionSeconds === null) {
+        action.time = formatted;
+        updated = true;
+        return;
+      }
+      const shifted = Math.max(0, Number((actionSeconds + delta).toFixed(6)));
+      action.time = secondsToTimecode(shifted);
       updated = true;
-    }
-  });
+    });
+  }
 
   const focusDescriptor = {
     kind: "group",

--- a/dmx.py
+++ b/dmx.py
@@ -602,14 +602,14 @@ class DMXOutput:
             self.set_channel(channel, value)
             return
 
-        start_value = self.get_channel(channel)
-        steps = max(int(duration * DMX_FPS), 1)
-        step_duration = duration / steps
-
         cancel_event = threading.Event()
         with self._transition_lock:
             self._cancel_channel_transition_locked(channel)
+            start_value = self.get_channel(channel)
             self._channel_transitions[channel] = cancel_event
+
+        steps = max(int(duration * DMX_FPS), 1)
+        step_duration = duration / steps
 
         def _worker() -> None:
             try:


### PR DESCRIPTION
## Summary
- ensure DMX fades recalculate their starting level after cancelling any in-flight transition so fades ramp from the live DMX value
- keep template-derived actions aligned with their relative offsets when a step time is edited in the builder UI

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5cc215918833299b897239fb5afd6