### PR TITLE
Add master color control support to DMX templates

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -876,6 +876,20 @@ input::-webkit-inner-spin-button {
   border-color: rgba(129, 140, 248, 0.85);
 }
 
+.preset-field select {
+  padding: 0.45rem 0.55rem;
+  border-radius: 0.45rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: rgba(30, 41, 59, 0.6);
+  color: inherit;
+  font-size: 0.95rem;
+}
+
+.preset-field select:focus {
+  outline: 2px solid rgba(129, 140, 248, 0.55);
+  border-color: rgba(129, 140, 248, 0.85);
+}
+
 .preset-values {
   display: flex;
   flex-direction: column;
@@ -1577,6 +1591,92 @@ input::-webkit-inner-spin-button {
 .preset-select .value-slider:disabled {
   opacity: 0.75;
   cursor: not-allowed;
+}
+
+.preset-select--master {
+  display: flex;
+  flex-direction: column;
+  gap: 0.6rem;
+}
+
+.preset-select__color {
+  appearance: none;
+  width: 3rem;
+  height: 2.5rem;
+  padding: 0;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 0.5rem;
+  background: transparent;
+  cursor: pointer;
+}
+
+.preset-select__color:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.6);
+  outline-offset: 2px;
+}
+
+.master-color-swatches {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.4rem;
+}
+
+.master-color-picker {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.6rem;
+  align-items: center;
+}
+
+.master-color-swatches__button {
+  width: 1.8rem;
+  height: 1.8rem;
+  border-radius: 999px;
+  border: 2px solid transparent;
+  background: transparent;
+  cursor: pointer;
+  position: relative;
+}
+
+.master-color-swatches__button::after {
+  content: "";
+  position: absolute;
+  inset: 0.15rem;
+  border-radius: inherit;
+  background: currentColor;
+}
+
+.master-color-swatches__button:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.6);
+  outline-offset: 2px;
+}
+
+.master-color-swatches__button.is-active {
+  border-color: rgba(148, 163, 184, 0.9);
+}
+
+.master-slider {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.master-slider__label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  min-width: 4.5rem;
+  text-transform: uppercase;
+}
+
+.master-slider__range {
+  flex: 1 1 10rem;
+}
+
+.master-slider__number {
+  width: 4.5ch;
+  min-width: 3.5ch;
 }
 
 .row-tools,

--- a/app.py
+++ b/app.py
@@ -154,6 +154,25 @@ def _generate_channel_preset_id(prefix: str) -> str:
     return f"{prefix}_{uuid.uuid4().hex}"
 
 
+CHANNEL_COMPONENT_VALUES = {
+    "red",
+    "green",
+    "blue",
+    "white",
+    "brightness",
+    "none",
+}
+
+
+def _normalize_channel_component(value: object) -> str:
+    if not isinstance(value, str):
+        return ""
+    normalized = value.strip().lower()
+    if normalized in CHANNEL_COMPONENT_VALUES:
+        return "" if normalized == "none" else normalized
+    return ""
+
+
 def _clamp(value: int, minimum: int, maximum: int) -> int:
     return max(minimum, min(maximum, value))
 
@@ -181,6 +200,8 @@ def sanitize_channel_preset(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         preset_id = _generate_channel_preset_id("preset")
     name = raw.get("name") if isinstance(raw.get("name"), str) else ""
     group = raw.get("group") if isinstance(raw.get("group"), str) else ""
+    component = _normalize_channel_component(raw.get("component"))
+
     try:
         channel_value = int(raw.get("channel", 1))
     except (TypeError, ValueError):
@@ -197,6 +218,7 @@ def sanitize_channel_preset(raw: Dict[str, Any]) -> Optional[Dict[str, Any]]:
         "name": name,
         "group": group,
         "channel": channel,
+        "component": component,
         "values": list(values),
     }
 

--- a/channel_presets.json
+++ b/channel_presets.json
@@ -5,6 +5,7 @@
       "name": "Left Light - Dimmer",
       "group": "Left Light",
       "channel": 1,
+      "component": "brightness",
       "values": [
         {
           "id": "left-light-dimmer-off",
@@ -38,6 +39,7 @@
       "name": "Left Light - Red",
       "group": "Left Light",
       "channel": 2,
+      "component": "red",
       "values": [
         {
           "id": "left-light-red-off",
@@ -56,6 +58,7 @@
       "name": "Left Light - Green",
       "group": "Left Light",
       "channel": 3,
+      "component": "green",
       "values": [
         {
           "id": "left-light-green-off",
@@ -74,6 +77,7 @@
       "name": "Left Light - Blue",
       "group": "Left Light",
       "channel": 4,
+      "component": "blue",
       "values": [
         {
           "id": "left-light-blue-off",
@@ -92,6 +96,7 @@
       "name": "Left Light - White",
       "group": "Left Light",
       "channel": 5,
+      "component": "white",
       "values": [
         {
           "id": "left-light-white-off",

--- a/dmx.py
+++ b/dmx.py
@@ -1104,6 +1104,7 @@ class DMXShowManager:
                     "templateId",
                     "templateInstanceId",
                     "templateRowId",
+                    "channelMasterId",
                 ):
                     value = raw.get(key)
                     if isinstance(value, str) and value:


### PR DESCRIPTION
## Summary
- add channel component metadata and master color picker controls to the DMX template builder UI
- extend template serialization/duplication logic to persist channel master selections and state
- persist channel master identifiers through the backend DMX show manager

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5ce316e108332899573c8e7802c8e