### PR TITLE
Map RGBW components across channel presets

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -767,6 +767,130 @@ input::-webkit-inner-spin-button {
   opacity: 0.85;
 }
 
+.color-settings__header {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 1rem;
+  align-items: flex-end;
+  justify-content: space-between;
+}
+
+.color-settings__header h2 {
+  margin: 0 0 0.35rem;
+  font-size: 1.3rem;
+}
+
+.color-settings__header p {
+  margin: 0;
+  max-width: 38rem;
+  opacity: 0.75;
+  font-size: 0.95rem;
+}
+
+.color-settings__actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.color-settings__list {
+  display: grid;
+  gap: 1rem;
+  margin-top: 1.25rem;
+}
+
+.color-settings__empty {
+  padding: 1rem 1.25rem;
+  border-radius: 0.6rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px dashed rgba(148, 163, 184, 0.35);
+  font-size: 0.95rem;
+  opacity: 0.85;
+}
+
+.color-card {
+  background: rgba(15, 23, 42, 0.8);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+  border-radius: 0.75rem;
+  padding: 1rem 1.25rem;
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+}
+
+.color-card__header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 0.75rem;
+}
+
+.color-card__title {
+  margin: 0;
+  font-size: 1.05rem;
+}
+
+.color-card__actions {
+  display: flex;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.color-card__body {
+  display: flex;
+  flex-direction: column;
+  gap: 0.9rem;
+}
+
+.color-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+  font-size: 0.95rem;
+}
+
+.color-field input[type="text"],
+.color-field input[type="number"] {
+  width: 100%;
+}
+
+.color-field--icon input[type="color"] {
+  width: 3rem;
+  height: 2.5rem;
+  padding: 0;
+  border-radius: 0.6rem;
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  background: transparent;
+  cursor: pointer;
+}
+
+.color-card__swatch {
+  display: flex;
+  align-items: center;
+  gap: 0.9rem;
+  flex-wrap: wrap;
+}
+
+.color-card__preview {
+  width: 3rem;
+  height: 3rem;
+  border-radius: 0.75rem;
+  border: 1px solid rgba(148, 163, 184, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(15, 23, 42, 0.45);
+  background: #ffffff;
+}
+
+.color-card__values {
+  display: grid;
+  gap: 0.6rem;
+  grid-template-columns: repeat(auto-fit, minmax(110px, 1fr));
+}
+
+.color-field--value input[type="number"] {
+  text-align: center;
+}
+
 .preset-card {
   background: rgba(15, 23, 42, 0.8);
   border: 1px solid rgba(148, 163, 184, 0.35);
@@ -1611,6 +1735,11 @@ input::-webkit-inner-spin-button {
 }
 
 .preset-select__color:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.6);
+  outline-offset: 2px;
+}
+
+.color-field--icon input[type="color"]:focus-visible {
   outline: 2px solid rgba(129, 140, 248, 0.6);
   outline-offset: 2px;
 }

--- a/DMX Template Builder/index.html
+++ b/DMX Template Builder/index.html
@@ -38,6 +38,15 @@
         class="builder-tab"
         role="tab"
         aria-selected="false"
+        data-tab="colors"
+      >
+        Color Presets
+      </button>
+      <button
+        type="button"
+        class="builder-tab"
+        role="tab"
+        aria-selected="false"
         data-tab="templates"
       >
         Light Templates
@@ -198,6 +207,34 @@
         </div>
       </header>
       <div id="channel-presets" class="preset-settings__list" aria-live="polite"></div>
+    </section>
+
+    <section
+      id="color-presets-panel"
+      class="color-settings tab-panel"
+      data-tab-panel="colors"
+      aria-labelledby="color-presets-heading"
+      hidden
+      aria-hidden="true"
+    >
+      <header class="color-settings__header">
+        <div>
+          <h2 id="color-presets-heading">Color Presets</h2>
+          <p>
+            Configure the quick select swatches for master controls, including their
+            display color and DMX RGB values.
+          </p>
+        </div>
+        <div class="color-settings__actions">
+          <button id="add-color-preset" type="button" class="secondary">
+            Add Color Preset
+          </button>
+          <button id="reset-color-presets" type="button" class="secondary">
+            Reset to Defaults
+          </button>
+        </div>
+      </header>
+      <div id="color-presets" class="color-settings__list" aria-live="polite"></div>
     </section>
 
     <section

--- a/channel_presets.json
+++ b/channel_presets.json
@@ -255,7 +255,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "brightness"
     },
     {
       "id": "right-light-red",
@@ -273,7 +274,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "red"
     },
     {
       "id": "right-light-green",
@@ -291,7 +293,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "green"
     },
     {
       "id": "right-light-blue",
@@ -309,7 +312,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "blue"
     },
     {
       "id": "right-light-white",
@@ -327,7 +331,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "white"
     },
     {
       "id": "right-light-strobe",
@@ -474,7 +479,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "brightness"
     },
     {
       "id": "back-light-red",
@@ -492,7 +498,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "red"
     },
     {
       "id": "back-light-green",
@@ -510,7 +517,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "green"
     },
     {
       "id": "back-light-blue",
@@ -528,7 +536,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "blue"
     },
     {
       "id": "back-light-white",
@@ -546,7 +555,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "white"
     },
     {
       "id": "back-light-strobe",
@@ -693,7 +703,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "brightness"
     },
     {
       "id": "front-light-red",
@@ -711,7 +722,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "red"
     },
     {
       "id": "front-light-green",
@@ -729,7 +741,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "green"
     },
     {
       "id": "front-light-blue",
@@ -747,7 +760,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "blue"
     },
     {
       "id": "front-light-white",
@@ -765,7 +779,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "white"
     },
     {
       "id": "front-light-strobe",
@@ -1213,7 +1228,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "brightness"
     },
     {
       "id": "mover-light-strobe",
@@ -1269,7 +1285,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "red"
     },
     {
       "id": "mover-light-beam-green",
@@ -1287,7 +1304,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "green"
     },
     {
       "id": "mover-light-beam-blue",
@@ -1305,7 +1323,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "blue"
     },
     {
       "id": "mover-light-beam-white",
@@ -1323,7 +1342,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "white"
     },
     {
       "id": "mover-light-laser-pattern",
@@ -1348,7 +1368,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "red"
     },
     {
       "id": "mover-light-laser-green",
@@ -1366,7 +1387,8 @@
           "name": "Full",
           "value": 255
         }
-      ]
+      ],
+      "component": "green"
     },
     {
       "id": "mover-light-white-flash",
@@ -1404,7 +1426,8 @@
           "name": "Super Fast",
           "value": 255
         }
-      ]
+      ],
+      "component": "white"
     },
     {
       "id": "mover-light-strip",

--- a/tests/test_channel_presets_api.py
+++ b/tests/test_channel_presets_api.py
@@ -1,5 +1,7 @@
 import json
 
+import json
+
 import pytest
 
 pytest.importorskip("flask")
@@ -43,6 +45,11 @@ def test_put_channel_presets_saves_and_returns_sanitized(channel_presets_tempfil
                 "channel": 20,
                 "values": [],
             },
+            {
+                "name": "Back Light - Red",
+                "group": "Back Light",
+                "channel": 21,
+            },
         ]
     }
 
@@ -53,18 +60,19 @@ def test_put_channel_presets_saves_and_returns_sanitized(channel_presets_tempfil
     assert "presets" in body
     returned = body["presets"]
     assert isinstance(returned, list)
-    assert len(returned) == 2
+    assert len(returned) == 3
     first = returned[0]
     assert first["id"] == "preset_custom"
     assert first["channel"] == 1  # clamped
     assert first["values"][0]["id"] == "value_custom"
     assert first["values"][0]["value"] == 255
     assert 0 <= first["values"][1]["value"] <= 255
+    assert returned[2]["component"] == "red"
 
     assert channel_presets_tempfile.exists()
     stored = json.loads(channel_presets_tempfile.read_text(encoding="utf-8"))
     assert "presets" in stored
-    assert len(stored["presets"]) == 2
+    assert len(stored["presets"]) == 3
 
 
 def test_put_channel_presets_rejects_invalid_payload():

--- a/tests/test_color_presets_api.py
+++ b/tests/test_color_presets_api.py
@@ -1,0 +1,77 @@
+import json
+
+import pytest
+
+pytest.importorskip("flask")
+
+import app as app_module
+
+
+@pytest.fixture(autouse=True)
+def color_presets_tempfile(tmp_path, monkeypatch):
+    temp_file = tmp_path / "color_presets.json"
+    monkeypatch.setattr(app_module, "COLOR_PRESETS_FILE", temp_file)
+    yield temp_file
+
+
+def test_get_color_presets_returns_defaults(color_presets_tempfile):
+    client = app_module.app.test_client()
+
+    response = client.get("/api/color-presets")
+
+    assert response.status_code == 200
+    body = response.get_json()
+    assert "presets" in body
+    presets = body["presets"]
+    assert isinstance(presets, list)
+    assert presets
+    first = presets[0]
+    assert set(first.keys()) == {"id", "name", "iconColor", "red", "green", "blue"}
+    assert not color_presets_tempfile.exists()
+
+
+def test_put_color_presets_sanitizes_and_saves(color_presets_tempfile):
+    client = app_module.app.test_client()
+
+    payload = {
+        "presets": [
+            {
+                "id": "color_custom",
+                "name": "Custom",
+                "iconColor": "not-a-color",
+                "red": 999,
+                "green": -5,
+                "blue": 20,
+            },
+            {
+                "name": "Secondary",
+                "rgb": {"r": 10, "g": 20, "b": 30},
+                "iconColor": "#abc",
+            },
+        ]
+    }
+
+    response = client.put("/api/color-presets", json=payload)
+
+    assert response.status_code == 200
+    data = response.get_json()
+    presets = data["presets"]
+    assert isinstance(presets, list)
+    assert len(presets) == 2
+
+    first, second = presets
+    assert first["id"] == "color_custom"
+    assert first["red"] == 255
+    assert first["green"] == 0
+    assert first["blue"] == 20
+    assert first["iconColor"] == "#ff0014"
+
+    assert second["red"] == 10
+    assert second["green"] == 20
+    assert second["blue"] == 30
+    assert second["iconColor"] == "#aabbcc"
+
+    assert color_presets_tempfile.exists()
+    stored = json.loads(color_presets_tempfile.read_text(encoding="utf-8"))
+    assert "presets" in stored
+    assert len(stored["presets"]) == 2


### PR DESCRIPTION
## Summary
- add component metadata to every RGBW and dimmer channel so masters are detected for each fixture
- cover movers and washes to ensure master controls can map brightness and white channels

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5db8a5b208332b59d574792047e14