### PR TITLE
Add flexible components to DMX master controls

### DIFF
--- a/DMX Template Builder/builder.css
+++ b/DMX Template Builder/builder.css
@@ -1809,6 +1809,31 @@ input::-webkit-inner-spin-button {
   min-width: 3.5ch;
 }
 
+.master-dropdown {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-top: 0.75rem;
+}
+
+.master-dropdown__label {
+  font-weight: 600;
+  font-size: 0.85rem;
+  letter-spacing: 0.02em;
+  text-transform: uppercase;
+  min-width: 4.5rem;
+}
+
+.master-dropdown__select {
+  flex: 1 1 auto;
+  min-width: 0;
+  padding: 0.35rem 0.5rem;
+  border-radius: 0.4rem;
+  border: 1px solid rgba(148, 163, 184, 0.6);
+  background-color: rgba(255, 255, 255, 0.9);
+  color: inherit;
+}
+
 .row-tools,
 .template-row__tools {
   display: flex;

--- a/tests/test_channel_presets_api.py
+++ b/tests/test_channel_presets_api.py
@@ -68,6 +68,10 @@ def test_put_channel_presets_saves_and_returns_sanitized(channel_presets_tempfil
     assert first["values"][0]["value"] == 255
     assert 0 <= first["values"][1]["value"] <= 255
     assert returned[2]["component"] == "red"
+    assert returned[2]["componentType"] == "color"
+    assert returned[2]["componentName"] == "Red"
+    assert returned[0]["componentType"] == ""
+    assert returned[0]["componentName"] == ""
 
     assert channel_presets_tempfile.exists()
     stored = json.loads(channel_presets_tempfile.read_text(encoding="utf-8"))


### PR DESCRIPTION
## Summary
- allow channel presets to capture component type and display names and persist master state sliders/dropdowns
- update the DMX Template Builder UI to support color, slider, and dropdown master controls with new styling
- extend API sanitization and tests to validate the new component metadata and master payloads

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5e2ccfa5c8332adbe1988d261e40d