### PR TITLE
Fix master slider parsing in light templates

### DIFF
--- a/app.py
+++ b/app.py
@@ -607,7 +607,12 @@ def sanitize_template_master_state(raw: Any, channel_master_id: str) -> Optional
                     numeric_value = int(value)
                 except (TypeError, ValueError):
                     continue
-                sliders[component] = _clamp(numeric_value, 0, 255)
+                clamped = _clamp(numeric_value, 0, 255)
+                sliders[component] = clamped
+                if component == "brightness" and "brightness" not in state:
+                    state["brightness"] = clamped
+                if component == "white" and "white" not in state:
+                    state["white"] = clamped
 
         dropdown_raw = raw.get("dropdownSelections")
         if isinstance(dropdown_raw, dict):

--- a/tests/test_light_templates.py
+++ b/tests/test_light_templates.py
@@ -40,3 +40,63 @@ def test_sanitize_template_row_infers_delay_type_when_missing():
     result = sanitize_template_row({"id": "row_delay", "duration": 3})
 
     assert result == {"id": "row_delay", "type": "delay", "duration": 3.0}
+
+
+def test_sanitize_template_row_master_preserves_primary_fields():
+    result = sanitize_template_row(
+        {
+            "id": "row_master",
+            "channel": 5,
+            "value": 120,
+            "channelMasterId": "master-1",
+            "master": {
+                "color": "#123456",
+                "brightness": "200",
+                "white": 150,
+                "sliders": {"custom": "90"},
+                "dropdownSelections": {"Mode": "Pulse"},
+            },
+        }
+    )
+
+    assert result == {
+        "id": "row_master",
+        "type": "action",
+        "channel": 5,
+        "value": 120,
+        "fade": 0.0,
+        "channelPresetId": None,
+        "valuePresetId": None,
+        "channelMasterId": "master-1",
+        "master": {
+            "id": "master-1",
+            "color": "#123456",
+            "brightness": 200,
+            "white": 150,
+            "sliders": {"custom": 90, "brightness": 200, "white": 150},
+            "dropdownSelections": {"mode": "Pulse"},
+        },
+    }
+
+
+def test_sanitize_template_row_master_extracts_brightness_from_sliders():
+    result = sanitize_template_row(
+        {
+            "id": "row_master_slider",
+            "channel": 7,
+            "value": 0,
+            "fade": 1.0,
+            "channelMasterId": "master-2",
+            "master": {
+                "sliders": {"Brightness": "85", "WHITE": 210, "Extra": 33}
+            },
+        }
+    )
+
+    assert result["master"] == {
+        "id": "master-2",
+        "color": "#ffffff",
+        "brightness": 85,
+        "white": 210,
+        "sliders": {"brightness": 85, "white": 210, "extra": 33},
+    }


### PR DESCRIPTION
## Summary
- ensure master template sanitization restores brightness and white values from slider components
- cover master template sanitization with tests for colors, sliders, and dropdowns

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e5fb8925f883329d1112e7c55ec020